### PR TITLE
Assume/Assert Cell Support

### DIFF
--- a/nmigen/__init__.py
+++ b/nmigen/__init__.py
@@ -1,4 +1,4 @@
-from .hdl.ast import Value, Const, C, Mux, Cat, Repl, Array, Signal, ClockSignal, ResetSignal
+from .hdl.ast import Value, Const, C, Mux, Cat, Repl, Array, Signal, ClockSignal, ResetSignal, Assert, Assume
 from .hdl.dsl import Module
 from .hdl.cd import ClockDomain
 from .hdl.ir import Fragment, Instance

--- a/nmigen/back/pysim.py
+++ b/nmigen/back/pysim.py
@@ -297,6 +297,12 @@ class _StatementCompiler(StatementVisitor):
             lhs(state, normalize(rhs(state), shape))
         return run
 
+    def on_Assert(self, stmt):
+        raise NotImplementedError("Asserts not yet implemented for Simulator backend.") # :nocov:
+
+    def on_Assume(self, stmt):
+        pass # :nocov:
+
     def on_Switch(self, stmt):
         test  = self.rrhs_compiler(stmt.test)
         cases = []

--- a/nmigen/back/rtlil.py
+++ b/nmigen/back/rtlil.py
@@ -565,6 +565,26 @@ class _StatementCompiler(xfrm.StatementVisitor):
                 stmt.rhs, lhs_bits, lhs_sign)
         self._case.assign(self.lhs_compiler(stmt.lhs), rhs_sigspec)
 
+    def on_Assert(self, stmt):
+        self(stmt._en.eq(1))
+        self(stmt._check.eq(stmt.test))
+        en_wire = self.rhs_compiler(stmt._en)
+        check_wire = self.rhs_compiler(stmt._check)
+        self.state.rtlil.cell("$assert", ports={
+            "\\A": check_wire,
+            "\\EN": en_wire,
+        }, params={ }, src=src(stmt.test.src_loc))
+
+    def on_Assume(self, stmt):
+        self(stmt._en.eq(1))
+        self(stmt._check.eq(stmt.test))
+        en_wire = self.rhs_compiler(stmt._en)
+        check_wire = self.rhs_compiler(stmt._check)
+        self.state.rtlil.cell("$assume", ports={
+            "\\A": check_wire,
+            "\\EN": en_wire,
+        }, params={ }, src=src(stmt.test.src_loc))
+
     def on_Switch(self, stmt):
         self._check_rhs(stmt.test)
 

--- a/nmigen/hdl/dsl.py
+++ b/nmigen/hdl/dsl.py
@@ -336,9 +336,9 @@ class Module(_ModuleBuilderRoot):
             self._pop_ctrl()
 
         for assign in Statement.wrap(assigns):
-            if not compat_mode and not isinstance(assign, Assign):
+            if not compat_mode and not isinstance(assign, (Assign, Assert, Assume)):
                 raise SyntaxError(
-                    "Only assignments may be appended to d.{}"
+                    "Only assignments, asserts, and assumes may be appended to d.{}"
                     .format(domain_name(domain)))
 
             for signal in assign._lhs_signals():

--- a/nmigen/hdl/xfrm.py
+++ b/nmigen/hdl/xfrm.py
@@ -142,6 +142,14 @@ class StatementVisitor(metaclass=ABCMeta):
         pass # :nocov:
 
     @abstractmethod
+    def on_Assert(self, stmt):
+        pass # :nocov:
+
+    @abstractmethod
+    def on_Assume(self, stmt):
+        pass # :nocov:
+
+    @abstractmethod
     def on_Switch(self, stmt):
         pass # :nocov:
 
@@ -155,6 +163,10 @@ class StatementVisitor(metaclass=ABCMeta):
     def on_statement(self, stmt):
         if type(stmt) is Assign:
             return self.on_Assign(stmt)
+        elif type(stmt) is Assert:
+            return self.on_Assert(stmt)
+        elif type(stmt) is Assume:
+            return self.on_Assume(stmt)
         elif isinstance(stmt, Switch):
             # Uses `isinstance()` and not `type() is` because nmigen.compat requires it.
             return self.on_Switch(stmt)
@@ -173,6 +185,12 @@ class StatementTransformer(StatementVisitor):
 
     def on_Assign(self, stmt):
         return Assign(self.on_value(stmt.lhs), self.on_value(stmt.rhs))
+
+    def on_Assert(self, stmt):
+        return Assert(self.on_value(stmt.test), _en=stmt._en, _check=stmt._check)
+
+    def on_Assume(self, stmt):
+        return Assume(self.on_value(stmt.test), _en=stmt._en, _check=stmt._check)
 
     def on_Switch(self, stmt):
         cases = OrderedDict((k, self.on_statement(s)) for k, s in stmt.cases.items())
@@ -294,6 +312,10 @@ class SwitchCleaner(StatementVisitor):
     def on_Assign(self, stmt):
         return stmt
 
+    on_Assert = on_Assign
+
+    on_Assume = on_Assign
+
     def on_Switch(self, stmt):
         cases = OrderedDict((k, self.on_statement(s)) for k, s in stmt.cases.items())
         if any(len(s) for s in cases.values()):
@@ -338,6 +360,10 @@ class LHSGroupAnalyzer(StatementVisitor):
     def on_Assign(self, stmt):
         self.unify(*stmt._lhs_signals())
 
+    on_Assert = on_Assign
+
+    on_Assume = on_Assign
+
     def on_Switch(self, stmt):
         for case_stmts in stmt.cases.values():
             self.on_statements(case_stmts)
@@ -361,6 +387,13 @@ class LHSGroupFilter(SwitchCleaner):
         any_lhs_signal = next(iter(stmt.lhs._lhs_signals()))
         if any_lhs_signal in self.signals:
             return stmt
+
+    def on_Assert(self, stmt):
+        any_lhs_signal = next(iter(stmt._lhs_signals()))
+        if any_lhs_signal in self.signals:
+            return stmt
+
+    on_Assume = on_Assert
 
 
 class _ControlInserter(FragmentTransformer):

--- a/nmigen/test/test_hdl_dsl.py
+++ b/nmigen/test/test_hdl_dsl.py
@@ -74,7 +74,7 @@ class DSLTestCase(FHDLTestCase):
     def test_d_asgn_wrong(self):
         m = Module()
         with self.assertRaises(SyntaxError,
-                msg="Only assignments may be appended to d.sync"):
+                msg="Only assignments, asserts, and assumes may be appended to d.sync"):
             m.d.sync += Switch(self.s1, {})
 
     def test_comb_wrong(self):


### PR DESCRIPTION
## Scope
This PR adds the beginning of formal verification support to `nmigen`. With this PR, a user can now write statements of the following form:

```
m.d.comb += Assert(foo == bar)
m.d.sync += Assert(baz == 0)

with m.If(quux):
    m.d.comb += Assume(dummy == 1)
```

The first statement in particular will create `Assert`s/`Assume`s analogous to `yosys`'s "`properties`":
```
assert property (foo == 0)
```

A `yosys` `property` is syntactic sugar for:
```
always @(*) assert(foo == 0)
```

The third statement is analogous to a SystemVerilog immediate `assert`/`assume`.

The generated RTLIL can then be fed to `yosys`, which outputs an `smtv2` file. Using `yosys-smtbmc` or `symbiyosys`, one can now run a basic formal verification flow using `nmigen`!

## Limitations
* Something analogous to `initial assume/assert` not yet supported (easy to add initial support, but I don't know what the semantics should be if they are used within an `If/Else/Switch` context.
* You can only do immediate asserts (in SystemVerilog, `property` is for concurrent asserts, and AFAIK `yosys` does not support these).