### PR TITLE
Give the top level scope a name to fix vcd file production

### DIFF
--- a/nmigen/back/pysim.py
+++ b/nmigen/back/pysim.py
@@ -448,7 +448,7 @@ class Simulator:
                     add_fragment(subfragment, (*scope, "#{}".format(index)))
                 else:
                     add_fragment(subfragment, (*scope, name))
-        add_fragment(root_fragment)
+        add_fragment(root_fragment, scope=("top",))
 
         def add_signal(signal):
             if signal not in self._signals:


### PR DESCRIPTION
At present the `root_fragment` in the pysim `hierarchy` has an empty `scope=()`, and when this is added to the vcd file we get:
```vcd
$scope module  $end
```
i.e. the top-level module has no name. This breaks gtkwave somewhat as you can't re-select the top level after selecting a submodule:

![image](https://user-images.githubusercontent.com/47219/50730504-b004d380-1146-11e9-9ce4-f9cbc5bdae52.png)

This patch sets the `root_fragment`'s scope to `"top"`, producing a vcd with a useful hierarchy:

![image](https://user-images.githubusercontent.com/47219/50730505-c0b54980-1146-11e9-8b35-b087665c67e1.png)

I can't see an obvious way to get a more useful name than "top" for the root fragment, but if one exists that would be even better.