### PR TITLE
Support for yosys' $anyconst and $anyseq cells

### DIFF
--- a/nmigen/__init__.py
+++ b/nmigen/__init__.py
@@ -1,4 +1,4 @@
-from .hdl.ast import Value, Const, C, Mux, Cat, Repl, Array, Signal, ClockSignal, ResetSignal, Assert, Assume
+from .hdl.ast import Value, Const, C, AnyConst, AnySeq, Mux, Cat, Repl, Array, Signal, ClockSignal, ResetSignal, Assert, Assume
 from .hdl.dsl import Module
 from .hdl.cd import ClockDomain
 from .hdl.ir import Fragment, Instance

--- a/nmigen/back/pysim.py
+++ b/nmigen/back/pysim.py
@@ -87,6 +87,12 @@ class _RHSValueCompiler(_ValueCompiler):
     def on_Const(self, value):
         return lambda state: value.value
 
+    def on_AnyConst(self, value):
+        raise NotImplementedError # :nocov:
+
+    def on_AnySeq(self, value):
+        raise NotImplementedError # :nocov:
+
     def on_Signal(self, value):
         if self.sensitivity is not None:
             self.sensitivity.add(value)
@@ -217,6 +223,12 @@ class _LHSValueCompiler(_ValueCompiler):
         self.rhs_compiler = rhs_compiler
 
     def on_Const(self, value):
+        raise TypeError # :nocov:
+
+    def on_AnyConst(self, value):
+        raise TypeError # :nocov:
+
+    def on_AnySeq(self, value):
         raise TypeError # :nocov:
 
     def on_Signal(self, value):

--- a/nmigen/back/rtlil.py
+++ b/nmigen/back/rtlil.py
@@ -370,6 +370,26 @@ class _RHSValueCompiler(_ValueCompiler):
             value_twos_compl = value.value & ((1 << value.nbits) - 1)
             return "{}'{:0{}b}".format(value.nbits, value_twos_compl, value.nbits)
 
+    def on_AnyConst(self, value):
+        res_bits, res_sign = value.shape()
+        res = self.s.rtlil.wire(width=res_bits)
+        self.s.rtlil.cell("$anyconst", ports={
+            "\\Y": res,
+        }, params={
+            "Y_WIDTH": res_bits,
+        }, src=src(value.src_loc))
+        return res
+
+    def on_AnySeq(self, value):
+        res_bits, res_sign = value.shape()
+        res = self.s.rtlil.wire(width=res_bits)
+        self.s.rtlil.cell("$anyseq", ports={
+            "\\Y": res,
+        }, params={
+            "Y_WIDTH": res_bits,
+        }, src=src(value.src_loc))
+        return res
+
     def on_Signal(self, value):
         wire_curr, wire_next = self.s.resolve(value)
         return wire_curr
@@ -501,6 +521,12 @@ class _RHSValueCompiler(_ValueCompiler):
 
 class _LHSValueCompiler(_ValueCompiler):
     def on_Const(self, value):
+        raise TypeError # :nocov:
+
+    def on_AnyConst(self, value):
+        raise TypeError # :nocov:
+
+    def on_AnySeq(self, value):
         raise TypeError # :nocov:
 
     def on_Operator(self, value):

--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -9,7 +9,7 @@ from ..tools import *
 
 
 __all__ = [
-    "Value", "Const", "C", "Operator", "Mux", "Part", "Slice", "Cat", "Repl",
+    "Value", "Const", "C", "AnyConst", "AnySeq", "Operator", "Mux", "Part", "Slice", "Cat", "Repl",
     "Array", "ArrayProxy",
     "Signal", "ClockSignal", "ResetSignal",
     "Statement", "Assign", "Assert", "Assume", "Switch", "Delay", "Tick",
@@ -252,6 +252,32 @@ class Const(Value):
 
 
 C = Const  # shorthand
+
+
+class AnyValue(Value):
+    def __init__(self, shape):
+        super().__init__(src_loc_at=0)
+        if isinstance(shape, int):
+            shape = shape, False
+        self.nbits, self.signed = shape
+        if not isinstance(self.nbits, int) or self.nbits < 0:
+            raise TypeError("Width must be a non-negative integer, not '{!r}'", self.nbits)
+
+    def shape(self):
+        return self.nbits, self.signed
+
+    def _rhs_signals(self):
+        return ValueSet()
+
+
+class AnyConst(AnyValue):
+    def __repr__(self):
+        return "(anyconst {}'{})".format(self.nbits, "s" if self.signed else "")
+
+
+class AnySeq(AnyValue):
+    def __repr__(self):
+        return "(anyseq {}'{})".format(self.nbits, "s" if self.signed else "")
 
 
 class Operator(Value):

--- a/nmigen/hdl/xfrm.py
+++ b/nmigen/hdl/xfrm.py
@@ -24,6 +24,14 @@ class ValueVisitor(metaclass=ABCMeta):
         pass # :nocov:
 
     @abstractmethod
+    def on_AnyConst(self, value):
+        pass # :nocov:
+
+    @abstractmethod
+    def on_AnySeq(self, value):
+        pass # :nocov:
+
+    @abstractmethod
     def on_Signal(self, value):
         pass # :nocov:
 
@@ -69,6 +77,10 @@ class ValueVisitor(metaclass=ABCMeta):
     def on_value(self, value):
         if type(value) is Const:
             new_value = self.on_Const(value)
+        elif type(value) is AnyConst:
+            new_value = self.on_AnyConst(value)
+        elif type(value) is AnySeq:
+            new_value = self.on_AnySeq(value)
         elif type(value) is Signal:
             new_value = self.on_Signal(value)
         elif type(value) is Record:
@@ -102,6 +114,12 @@ class ValueVisitor(metaclass=ABCMeta):
 
 class ValueTransformer(ValueVisitor):
     def on_Const(self, value):
+        return value
+
+    def on_AnyConst(self, value):
+        return value
+
+    def on_AnySeq(self, value):
         return value
 
     def on_Signal(self, value):


### PR DESCRIPTION
`AnyConst` and `AnySeq` correspond to to the `$anyconst` and `$anyseq` RTLIL cells. They are useful for formal verification to represent "any value that doesn't change", and "any value that _can_ change to another arbitrary value each clock cycle" respectively.

Usage is analogous to declaring a `Constant` or `Signal`:

```
self.foo = AnyConst(2)
self.bar = AnySeq(16)
```