### PR TITLE
cli: add missing default for `generate`

### DIFF
--- a/nmigen/cli.py
+++ b/nmigen/cli.py
@@ -16,6 +16,7 @@ def main_parser(parser=None):
         help="generate RTLIL or Verilog from the design")
     p_generate.add_argument("-t", "--type", dest="generate_type",
         metavar="LANGUAGE", choices=["il", "v"],
+        default="v",
         help="generate LANGUAGE (il for RTLIL, v for Verilog; default: %(default)s)")
     p_generate.add_argument("generate_file",
         metavar="FILE", type=argparse.FileType("w"), nargs="?",


### PR DESCRIPTION
There should probably be a default for generate (as there is is hint already). This adds `v` as default for `-t`. 