### PR TITLE
Give hint when user forgets to return `Module` from `elaborate`.

### DIFF
--- a/nmigen/hdl/ir.py
+++ b/nmigen/hdl/ir.py
@@ -19,6 +19,10 @@ class Fragment:
         if isinstance(obj, Fragment):
             return obj
         if not hasattr(obj, "elaborate"): # :deprecated:
+            if not hasattr(obj, "get_fragment"): # :deprecated:
+                raise AttributeError("'{}' object has no attribute 'elaborate' or 'get_fragment'."
+                                     " Did you remember to return a Module object from each user-defined 'elaborate' or 'get_fragment' method?"
+                                     .format(type(obj).__name__))
             return Fragment.get(obj.get_fragment(platform), platform)
         return Fragment.get(obj.elaborate(platform), platform)
 

--- a/nmigen/test/test_hdl_ir.py
+++ b/nmigen/test/test_hdl_ir.py
@@ -519,6 +519,15 @@ class FragmentHierarchyConflictTestCase(FHDLTestCase):
         self.assertEqual(self.f1.subfragments, [])
 
 
+class FragmentGetBadInputTestCase(FHDLTestCase):
+    def test_input_none(self):
+        with self.assertRaises(AttributeError,
+                msg="'NoneType' object has no attribute 'elaborate' or 'get_fragment'."
+                " Did you remember to return a Module object from each user-defined 'elaborate'"
+                " or 'get_fragment' method?"):
+            Fragment.get(None, None)
+
+
 class InstanceTestCase(FHDLTestCase):
     def setUp_cpu(self):
         self.rst = Signal()


### PR DESCRIPTION
Multiple times, I have forgotten to return a `Module` from `elaborate`, and I've found the resulting error to be unhelpful (even though I realize what it means now). The following traceback is the [alu.py](https://github.com/m-labs/nmigen/blob/master/examples/alu.py#L23) example with line 23 commented out:

```
$ python3 alu.py generate
Traceback (most recent call last):
  File "alu.py", line 28, in <module>
    main(alu, ports=[alu.sel, alu.a, alu.b, alu.o, alu.co])
  File "C:\msys64\home\william\src\nmigen\nmigen\cli.py", line 76, in main
    main_runner(parser, parser.parse_args(), *args, **kwargs)
  File "C:\msys64\home\william\src\nmigen\nmigen\cli.py", line 46, in main_runner
    fragment = Fragment.get(design, platform)
  File "C:\msys64\home\william\src\nmigen\nmigen\hdl\ir.py", line 23, in get
    return Fragment.get(obj.elaborate(platform), platform)
  File "C:\msys64\home\william\src\nmigen\nmigen\hdl\ir.py", line 22, in get
    return Fragment.get(obj.get_fragment(platform), platform)
AttributeError: 'NoneType' object has no attribute 'get_fragment'
```

With this PR, I have added code to give a hint to users what the problem is _likely_ to be. The traceback is changed to the following:

```
$ python3 alu.py generate
Traceback (most recent call last):
  File "alu.py", line 28, in <module>
    main(alu, ports=[alu.sel, alu.a, alu.b, alu.o, alu.co])
  File "C:\msys64\home\william\src\nmigen\nmigen\cli.py", line 76, in main
    main_runner(parser, parser.parse_args(), *args, **kwargs)
  File "C:\msys64\home\william\src\nmigen\nmigen\cli.py", line 46, in main_runner
    fragment = Fragment.get(design, platform)
  File "C:\msys64\home\william\src\nmigen\nmigen\hdl\ir.py", line 27, in get
    return Fragment.get(obj.elaborate(platform), platform)
  File "C:\msys64\home\william\src\nmigen\nmigen\hdl\ir.py", line 25, in get
    .format(type(obj).__name__))
AttributeError: 'NoneType' object has no attribute 'elaborate' or 'get_fragment'. Did you remember to return a Module object from each user-defined 'elaborate' or 'get_fragment' method?
```