### PR TITLE
setup.py: constrain Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     license="BSD",
     install_requires=["pyvcd>=0.1.4", "bitarray"],
     packages=find_packages(),
+    python_requires=">3.6",
     project_urls={
         #"Documentation": "https://glasgow.readthedocs.io/",
         "Source Code": "https://github.com/m-labs/nmigen",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license="BSD",
     install_requires=["pyvcd>=0.1.4", "bitarray"],
     packages=find_packages(),
-    python_requires=">3.6",
+    python_requires=">=3.6",
     project_urls={
         #"Documentation": "https://glasgow.readthedocs.io/",
         "Source Code": "https://github.com/m-labs/nmigen",


### PR DESCRIPTION
Installation should be constraint to supported Python versions, using `python_requires`, refer to [1] for details.

[1] https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires