### PR TITLE
Fix CDC issue in async FIFO: ensure that Gray code pointers are registered before resynchronisation.

### DIFF
--- a/nmigen/test/test_lib_fifo.py
+++ b/nmigen/test/test_lib_fifo.py
@@ -164,14 +164,17 @@ class FIFOContractSpec:
         m = Module()
         m.submodules.dut = fifo = self.fifo
 
+        initstate = Signal()
+        m.submodules += Instance("$initstate", o_Y=initstate)
+
         m.domains += ClockDomain("sync")
-        m.d.comb += ResetSignal().eq(0)
+        m.d.comb += ResetSignal().eq(initstate)
         if self.wdomain != "sync":
             m.domains += ClockDomain(self.wdomain)
-            m.d.comb += ResetSignal(self.wdomain).eq(0)
+            m.d.comb += ResetSignal(self.wdomain).eq(initstate)
         if self.rdomain != "sync":
             m.domains += ClockDomain(self.rdomain)
-            m.d.comb += ResetSignal(self.rdomain).eq(0)
+            m.d.comb += ResetSignal(self.rdomain).eq(initstate)
 
         if hasattr(fifo, "replace"):
             m.d.comb += fifo.replace.eq(0)
@@ -211,9 +214,6 @@ class FIFOContractSpec:
                     ]
                 with m.If((read_1 == entry_1) & (read_2 == entry_2)):
                     m.next = "DONE"
-
-        initstate = Signal()
-        m.submodules += Instance("$initstate", o_Y=initstate)
         with m.If(initstate):
             m.d.comb += Assume(write_fsm.ongoing("WRITE-1"))
             m.d.comb += Assume(read_fsm.ongoing("READ"))


### PR DESCRIPTION
The AsyncFIFO class is subtly different from the Clifford Cummings paper referenced in the source code. Here is a diagram showing the difference:

![](https://i.imgur.com/kryOLNq.png)

In the current nMigen code, there is a path that goes from:

- `produce` counter register in the write domain
- -> `GrayEncoder` 
- -> `MultiReg` in the read domain.

The problem is that there is a narrow window after a write clock edge where all of the Gray pointer bits may toggle, due to static hazards in the encoder, since all encoder _inputs_ can toggle simultaneously. If you sample this with an asynchronous clock, it's possible to see a completely wrong value for the `produce` pointer, which can cause irreversible corruption/loss of data.

I've only shown this for the `produce` pointer, but the same is true in the other direction too. The fix is to drive the Gray encoder from the binary counter register's input, rather than its output, and register the encoder output before resynchronising. From a synchronous point of view this behaves the same as the old Gray count, so the full/empty logic stays the same.

This bug will only be observed with a low probability, and may not be observed at all, e.g. if your two asynchronous clocks share some fixed rational relationship with a common clock source through PLLs, which affects the distribution of the relative phase of one observed at the rising edge of the other. However it _is_ a legitimate bug, with fatal consequences.

This code is not ready to merge:

- So far I've only run the FIFO smoke test on it. I haven't yet figured out how to run the formal test :( and it also needs soak testing on an FPGA board with two _completely_ separate oscillators.
- The pointer `MultiReg`s should ideally be resettable (although that is a different conversation!)
- I added a helper class, `GrayBinCounter`, which is currently only used by `AsyncFIFO`. It contains some extra detail, like putting a `no_retiming` attribute on the Gray register.
    - Currently I'm passing the domain name into the `__init__` of this class, like `MultiReg`, but I saw references elsewhere to the `DomainRenamer` class, which seems cleaner. However it seems you can only call this on `Fragment`s, not `Modules`, and I currently don't know what a `Fragment` is :)
    - If you would prefer not to have an extra helper class, I can give an alternative patch that just modifies `AsyncFIFO`. It just looks a bit copy-pastey.

I'm really new to nMigen, so this code definitely needs a close review.