### PR TITLE
WIP: Expand and document lib.cdc

### DIFF
--- a/nmigen/lib/cdc.py
+++ b/nmigen/lib/cdc.py
@@ -2,7 +2,13 @@ from .. import *
 from math import gcd
 
 
-__all__ = ["MultiReg", "ResetSynchronizer", "PulseSynchronizer", "Gearbox"]
+__all__ = [
+    "MultiReg",
+    "ResetSynchronizer",
+    "PulseSynchronizer",
+    "BusSynchronizer",
+    "Gearbox"
+]
 
 
 def _incr(signal, modulo):
@@ -135,7 +141,6 @@ class PulseSynchronizer(Elaboratable):
 
     Parameters
     ----------
-
     idomain : str
         Name of input clock domain.
     odomain : str
@@ -169,6 +174,92 @@ class PulseSynchronizer(Elaboratable):
 
         return m
 
+class BusSynchronizer(Elaboratable):
+    """Pass a multi-bit signal safely between clock domains.
+
+    Ensures that all bits presented at ``o`` form a single word that was present synchronously at
+    ``i`` in the input clock domain (unlike direct use of MultiReg).
+
+    Parameters
+    ----------
+    width : int > 0
+        Width of the bus to be synchronized
+    idomain : str
+        Name of input clock domain
+    odomain : str
+        Name of output clock domain
+    sync_stages : int >= 2
+        Number of synchronisation stages used in the req/ack pulse synchronizers. Lower than 2 is
+        unsafe. Higher values increase safety for high-frequency designs, but increase latency too.
+    timeout : int >= 0
+        The request from idomain is re-sent if ``timeout`` cycles elapse without a response.
+        ``timeout`` = 0 disables this feature.
+
+    Attributes
+    ----------
+    i : Signal(width), in
+        Input signal, sourced from ``idomain``
+    o : Signal(width), out
+        Resynchronized version of ``i``, driven to ``odomain``
+    """
+    def __init__(self, width, idomain, odomain, sync_stages=2, timeout = 127):
+        if not isinstance(width, int) or width < 1:
+            raise TypeError("width must be a positive integer, not '{!r}'".format(width))
+        if not isinstance(sync_stages, int) or sync_stages < 2:
+            raise TypeError("sync_stages must be an integer > 1, not '{!r}'".format(sync_stages))
+        if not isinstance(timeout, int) or timeout < 0:
+            raise TypeError("timeout must be a non-negative integer, not '{!r}'".format(timeout))
+
+        self.i = Signal(width)
+        self.o = Signal(width, attrs={"no_retiming": True})
+        self.width = width
+        self.idomain = idomain
+        self.odomain = odomain
+        self.sync_stages = sync_stages
+        self.timeout = timeout
+
+    def elaborate(self, platform):
+        m = Module()
+        if self.width == 1:
+            m.submodules += MultiReg(self.i, self.o, odomain=self.odomain, n=self.sync_stages)
+            return m
+
+        req = Signal()
+        ack_o = Signal()
+        ack_i = Signal()
+
+        sync_io = m.submodules.sync_io = \
+            PulseSynchronizer(self.idomain, self.odomain, self.sync_stages)
+        sync_oi = m.submodules.sync_oi = \
+            PulseSynchronizer(self.odomain, self.idomain, self.sync_stages)
+
+        if self.timeout != 0:
+            countdown = Signal(max=self.timeout, reset=self.timeout)
+            with m.If(ack_i | req):
+                m.d[self.idomain] += countdown.eq(self.timeout)
+            with m.Else():
+                m.d[self.idomain] += countdown.eq(countdown - countdown.bool())
+
+        start = Signal(reset=1)
+        m.d[self.idomain] += start.eq(0)
+        m.d.comb += [
+            req.eq(start | ack_i | (self.timeout != 0 and countdown == 0)),
+            sync_io.i.eq(req),
+            ack_o.eq(sync_io.o),
+            sync_oi.i.eq(ack_o),
+            ack_i.eq(sync_oi.o)
+        ]
+
+        buf_i = Signal(self.width, attrs={"no_retiming": True})
+        buf_o = Signal(self.width)
+        with m.If(ack_i):
+            m.d[self.idomain] += buf_i.eq(self.i)
+        sync_data = m.submodules.sync_data = \
+            MultiReg(buf_i, buf_o, odomain=self.odomain, n=self.sync_stages - 1)
+        with m.If(ack_o):
+            m.d[self.odomain] += self.o.eq(buf_o)
+
+        return m
 
 class Gearbox(Elaboratable):
     """Adapt the width of a continous datastream.

--- a/nmigen/lib/cdc.py
+++ b/nmigen/lib/cdc.py
@@ -50,6 +50,8 @@ class MultiReg(Elaboratable):
     MultiReg is reset by the ``odomain`` reset only.
     """
     def __init__(self, i, o, odomain="sync", n=2, reset=0, reset_less=True):
+        if not isinstance(n, int) or n < 1:
+            raise TypeError("n must be a positive integer, not '{!r}'".format(n))
         self.i = i
         self.o = o
         self.odomain = odomain
@@ -70,7 +72,27 @@ class MultiReg(Elaboratable):
 
 
 class ResetSynchronizer(Elaboratable):
+    """Synchronize the deassertion of a reset to a local clock.
+
+    Output `assertion` is asynchronous, so the local clock need not be free-running.
+
+    Parameters
+    ----------
+    arst : Signal(1), out
+        Asynchronous reset signal, to be synchronized.
+    domain : str
+        Name of domain to synchronize reset to.
+    n : int, >=1
+        Number of clock edges from input deassertion to output deassertion
+
+    Override
+    --------
+    Define the ``get_reset_sync`` platform attribute to override the implementation of
+    ResetSynchronizer, e.g. to instantiate library cells directly.
+    """
     def __init__(self, arst, domain="sync", n=2):
+        if not isinstance(n, int) or n < 1:
+            raise TypeError("n must be a positive integer, not '{!r}'".format(n))
         self.arst = arst
         self.domain = domain
 

--- a/nmigen/lib/cdc.py
+++ b/nmigen/lib/cdc.py
@@ -335,46 +335,46 @@ class Gearbox(Elaboratable):
 
     Parameters
     ----------
-    iwidth : int
+    width_i : int
         Bit width of the input
     cd_i : str
         Name of input clock domain
-    owidth : int
+    width_o : int
         Bit width of the output
     cd_o : str
         Name of output clock domain
 
     Attributes
     ----------
-    i : Signal(iwidth), in
+    i : Signal(width_i), in
         Input datastream. Sampled on every input clock.
-    o : Signal(owidth), out
+    o : Signal(width_o), out
         Output datastream. Transitions on every output clock.
     """
-    def __init__(self, iwidth, cd_i, owidth, cd_o):
-        if not isinstance(iwidth, int) or iwidth < 1:
-            raise TypeError("iwidth must be a positive integer, not '{!r}'".format(iwidth))
-        if not isinstance(owidth, int) or owidth < 1:
-            raise TypeError("owidth must be a positive integer, not '{!r}'".format(owidth))
+    def __init__(self, width_i, cd_i, width_o, cd_o):
+        if not isinstance(width_i, int) or width_i < 1:
+            raise TypeError("width_i must be a positive integer, not '{!r}'".format(width_i))
+        if not isinstance(width_o, int) or width_o < 1:
+            raise TypeError("width_o must be a positive integer, not '{!r}'".format(width_o))
 
-        self.i = Signal(iwidth)
-        self.o = Signal(owidth)
-        self.iwidth = iwidth
+        self.i = Signal(width_i)
+        self.o = Signal(width_o)
+        self.width_i = width_i
         self.cd_i = cd_i
-        self.owidth = owidth
+        self.width_o = width_o
         self.cd_o = cd_o
 
-        storagesize = iwidth * owidth // gcd(iwidth, owidth)
-        while storagesize // iwidth < 4:
+        storagesize = width_i * width_o // gcd(width_i, width_o)
+        while storagesize // width_i < 4:
             storagesize *= 2
-        while storagesize // owidth < 4:
+        while storagesize // width_o < 4:
             storagesize *= 2
 
         self._storagesize = storagesize
-        self._ichunks = storagesize // self.iwidth
-        self._ochunks = storagesize // self.owidth
-        assert(self._ichunks * self.iwidth == storagesize)
-        assert(self._ochunks * self.owidth == storagesize)
+        self._ichunks = storagesize // self.width_i
+        self._ochunks = storagesize // self.width_o
+        assert(self._ichunks * self.width_i == storagesize)
+        assert(self._ochunks * self.width_o == storagesize)
 
     def elaborate(self, platform):
         m = Module()
@@ -389,13 +389,13 @@ class Gearbox(Elaboratable):
 
         with m.Switch(iptr):
             for n in range(self._ichunks):
-                s = slice(n * self.iwidth, (n + 1) * self.iwidth)
+                s = slice(n * self.width_i, (n + 1) * self.width_i)
                 with m.Case(n):
                     m.d[self.cd_i] += storage[s].eq(self.i)
 
         with m.Switch(optr):
             for n in range(self._ochunks):
-                s = slice(n * self.owidth, (n + 1) * self.owidth)
+                s = slice(n * self.width_o, (n + 1) * self.width_o)
                 with m.Case(n):
                     m.d[self.cd_o] += self.o.eq(storage[s])
 

--- a/nmigen/lib/cdc.py
+++ b/nmigen/lib/cdc.py
@@ -98,7 +98,7 @@ class ResetSynchronizer(Elaboratable):
     domain : str
         Name of domain to synchronize reset to.
     n : int, >=1
-        Number of clock edges from input deassertion to output deassertion
+        Number of metastability flops between input and output
 
     Override
     --------

--- a/nmigen/lib/cdc.py
+++ b/nmigen/lib/cdc.py
@@ -229,8 +229,9 @@ class BusSynchronizer(Elaboratable):
         ack_o = Signal()
         ack_i = Signal()
 
+        # Extra flop on i->o to avoid race between data and request
         sync_io = m.submodules.sync_io = \
-            PulseSynchronizer(self.idomain, self.odomain, self.sync_stages)
+            PulseSynchronizer(self.idomain, self.odomain, self.sync_stages + 1)
         sync_oi = m.submodules.sync_oi = \
             PulseSynchronizer(self.odomain, self.idomain, self.sync_stages)
 
@@ -256,7 +257,7 @@ class BusSynchronizer(Elaboratable):
         with m.If(ack_i):
             m.d[self.idomain] += buf_i.eq(self.i)
         sync_data = m.submodules.sync_data = \
-            MultiReg(buf_i, buf_o, odomain=self.odomain, n=self.sync_stages - 1)
+            MultiReg(buf_i, buf_o, odomain=self.odomain, n=self.sync_stages)
         with m.If(ack_o):
             m.d[self.odomain] += self.o.eq(buf_o)
 

--- a/nmigen/lib/fifo.py
+++ b/nmigen/lib/fifo.py
@@ -316,7 +316,7 @@ class AsyncFIFO(Elaboratable, FIFOInterface):
         produce_enc = m.submodules.produce_enc = \
             GrayEncoder(self._ctr_bits)
         produce_cdc = m.submodules.produce_cdc = \
-            MultiReg(produce_w_gry, produce_r_gry, odomain="read")
+            MultiReg(produce_w_gry, produce_r_gry, cd_o="read")
         m.d.comb  += produce_enc.i.eq(produce_w_nxt),
         m.d.write += produce_w_gry.eq(produce_enc.o)
 
@@ -325,7 +325,7 @@ class AsyncFIFO(Elaboratable, FIFOInterface):
         consume_enc = m.submodules.consume_enc = \
             GrayEncoder(self._ctr_bits)
         consume_cdc = m.submodules.consume_cdc = \
-            MultiReg(consume_r_gry, consume_w_gry, odomain="write")
+            MultiReg(consume_r_gry, consume_w_gry, cd_o="write")
         m.d.comb  += consume_enc.i.eq(consume_r_nxt)
         m.d.read  += consume_r_gry.eq(consume_enc.o)
 

--- a/nmigen/test/test_lib_cdc.py
+++ b/nmigen/test/test_lib_cdc.py
@@ -193,8 +193,8 @@ class BusSynchronizerTestCase(FHDLTestCase):
                 for i in range(10):
                     testval = i % (2 ** width)
                     yield bs.i.eq(testval)
-                    # 6-cycle round trip, and if one in progress, must complete first:
-                    for j in range(11):
+                    # 7-cycle round trip, and if one in progress, must complete first:
+                    for j in range(13):
                         yield Tick()
                     self.assertEqual((yield bs.o), testval)
             sim.add_process(process)

--- a/nmigen/test/test_lib_cdc.py
+++ b/nmigen/test/test_lib_cdc.py
@@ -19,6 +19,14 @@ class MultiRegTestCase(FHDLTestCase):
         m = MultiReg(i, o, n=1)
         m = MultiReg(i, o, reset=-1)
 
+    def test_platform(self):
+        platform = lambda: None
+        platform.get_multi_reg = lambda m: "foobar{}".format(len(m._regs))
+        i = Signal()
+        o = Signal()
+        m = MultiReg(i, o, n=5)
+        self.assertEqual(m.elaborate(platform), "foobar5")
+
     def test_basic(self):
         i = Signal()
         o = Signal()
@@ -64,6 +72,13 @@ class ResetSynchronizerTestCase(FHDLTestCase):
         with self.assertRaises(TypeError):
             r = ResetSynchronizer(arst, n="a")
         r = ResetSynchronizer(arst)
+
+    def test_platform(self):
+        platform = lambda: None
+        platform.get_reset_sync = lambda m: "foobar{}".format(len(m._regs))
+        arst = Signal()
+        rs = ResetSynchronizer(arst, n=6)
+        self.assertEqual(rs.elaborate(platform), "foobar6")
 
     def test_basic(self):
         arst = Signal()

--- a/nmigen/test/test_lib_cdc.py
+++ b/nmigen/test/test_lib_cdc.py
@@ -5,6 +5,20 @@ from ..lib.cdc import *
 
 
 class MultiRegTestCase(FHDLTestCase):
+    def test_paramcheck(self):
+        i = Signal()
+        o = Signal()
+        with self.assertRaises(TypeError):
+            m = MultiReg(i, o, n=0)
+        with self.assertRaises(TypeError):
+            m = MultiReg(i, o, n="x")
+        with self.assertRaises(ValueError):
+            m = MultiReg(i, o, n=2, reset="a")
+        with self.assertRaises(TypeError):
+            m = MultiReg(i, o, n=2, reset=i)
+        m = MultiReg(i, o, n=1)
+        m = MultiReg(i, o, reset=-1)
+
     def test_basic(self):
         i = Signal()
         o = Signal()
@@ -43,6 +57,14 @@ class MultiRegTestCase(FHDLTestCase):
 
 
 class ResetSynchronizerTestCase(FHDLTestCase):
+    def test_paramcheck(self):
+        arst = Signal()
+        with self.assertRaises(TypeError):
+            r = ResetSynchronizer(arst, n=0)
+        with self.assertRaises(TypeError):
+            r = ResetSynchronizer(arst, n="a")
+        r = ResetSynchronizer(arst)
+
     def test_basic(self):
         arst = Signal()
         m = Module()


### PR DESCRIPTION
Very much a work in progress, but I wanted to open early to get feedback on the approach/direction. I'm porting/rewriting some of the missing modules from migen.genlib.cdc.

Currently in this patch set:

- Add docstrings to the existing modules. I tried to copy the "house style" I saw elsewhere.
- Basic checking to give more meaningful traces when you do something like request a MultiReg of length 0. Again I tried to copy the idioms I saw elsewhere
- Implement PulseSynchronizer
- Implement Gearbox

Known issues:
- Smoke tests only; no formal checks
- Checks are limited by single-clock simulation -- maybe it was a bad idea to play with the CDC library first :)
- I'm passing in the domain names rather than using DomainRenamer. Not sure whether it's best to leave this PR open until this is in place, or merge early so people can start hacking on this. Not my decision :)
- The storage size calculation in this version of Gearbox is different to the one in Migen. IMO the old one was unsafe, but this one may be too conservative. I could also be plain wrong!
- (edit:) The output mux on the Gearbox is driven from two clock domains. This is a legitimate thing to do here, but I saw mention somewhere that doing this should cause an error.

I definitely still intend to port:
- BusSynchronizer
- ElasticBuffer

And we probably ought to do something about GrayCounter at some point, but I think it's less important than the others.

As a general style question, there seem to be two ways of doing module wiring in `nmigen.lib` at the moment. One is to pass external signals into `__init__`, which gives you more of a Verilog-style instantiation. The other is to create "port" signals in `__init__`, which the parent then wires up during elaboration. I've used the second style because it seems a bit cleaner, and doesn't require creating extraneous signals like in Verilog, but not sure if this is the right thing to do?

