### PR TITLE
Change name seperator for siganls in records to double underscore

### DIFF
--- a/nmigen/hdl/rec.py
+++ b/nmigen/hdl/rec.py
@@ -72,7 +72,7 @@ class Record(Value):
         def concat(a, b):
             if a is None:
                 return b
-            return "{}_{}".format(a, b)
+            return "{}__{}".format(a, b)
 
         self.layout = Layout.wrap(layout)
         self.fields = OrderedDict()

--- a/nmigen/test/test_hdl_rec.py
+++ b/nmigen/test/test_hdl_rec.py
@@ -65,11 +65,11 @@ class RecordTestCase(FHDLTestCase):
             ])
         ])
 
-        self.assertEqual(repr(r), "(rec r stb data (rec r_info a b))")
+        self.assertEqual(repr(r), "(rec r stb data (rec r__info a b))")
         self.assertEqual(len(r),  35)
         self.assertIsInstance(r.stb, Signal)
-        self.assertEqual(r.stb.name, "r_stb")
-        self.assertEqual(r["stb"].name, "r_stb")
+        self.assertEqual(r.stb.name, "r__stb")
+        self.assertEqual(r["stb"].name, "r__stb")
 
     def test_unnamed(self):
         r = [Record([


### PR DESCRIPTION
This PR changes the seperator for signal names in records from a single underscore to a double underscore. When creating a Record, the signals inside it are then named `recordname__fieldname`.

This gives one more useful information, when looking at the signal names of fields which themselves contain underscores. E.g. `record__some_field` is now unambiguous :)

It closes #48.