### PR TITLE
 fix global , and allow easy subclassing of Platform

### DIFF
--- a/nmigen/build/plat.py
+++ b/nmigen/build/plat.py
@@ -85,6 +85,12 @@ class Platform(ConstraintManager, metaclass=ABCMeta):
 
         self._prepared   = False
 
+        self.extend()
+
+    def extend(self):
+        "add resources and config in subclass"
+        pass
+
     def add_file(self, filename, content):
         if not isinstance(filename, str):
             raise TypeError("File name must be a string")

--- a/nmigen/vendor/board/tinyfpga_bx.py
+++ b/nmigen/vendor/board/tinyfpga_bx.py
@@ -13,7 +13,7 @@ class TinyFPGABXPlatform(TinyProgrammerMixin, LatticeICE40Platform):
     ]
     resources  = [
         Resource("clk16", 0, Pins("B2", dir="i"),
-                 extras={"GLOBAL": 1, "IO_STANDARD": "SB_LVCMOS33"}),
+                 extras={"GLOBAL": "1", "IO_STANDARD": "SB_LVCMOS33"}),
 
         Resource("user_led", 0, Pins("B3", dir="o"), extras={"IO_STANDARD": "SB_LVCMOS33"}),
 


### PR DESCRIPTION
The global in the tinyfpga_bx board was an integer not a string. Added extend to platform to make subclassing and adding resources easier.
