### PR TITLE
Clean up Xilinx platform code

### DIFF
--- a/nmigen/vendor/lattice_ice40.py
+++ b/nmigen/vendor/lattice_ice40.py
@@ -129,7 +129,7 @@ class LatticeICE40Platform(TemplatedPlatform):
                 i_D=d,
                 o_Q=q)
 
-        def get_i_inverter(y, invert):
+        def get_ixor(y, invert):
             if invert is None:
                 return y
             else:
@@ -144,7 +144,7 @@ class LatticeICE40Platform(TemplatedPlatform):
                         o_O=y[bit])
                 return a
 
-        def get_o_inverter(a, invert):
+        def get_oxor(a, invert):
             if invert is None:
                 return a
             else:
@@ -168,16 +168,16 @@ class LatticeICE40Platform(TemplatedPlatform):
 
         if "i" in pin.dir:
             if pin.xdr < 2:
-                pin_i  = get_i_inverter(pin.i,  i_invert)
+                pin_i  = get_ixor(pin.i,  i_invert)
             elif pin.xdr == 2:
-                pin_i0 = get_i_inverter(pin.i0, i_invert)
-                pin_i1 = get_i_inverter(pin.i1, i_invert)
+                pin_i0 = get_ixor(pin.i0, i_invert)
+                pin_i1 = get_ixor(pin.i1, i_invert)
         if "o" in pin.dir:
             if pin.xdr < 2:
-                pin_o  = get_o_inverter(pin.o,  o_invert)
+                pin_o  = get_oxor(pin.o,  o_invert)
             elif pin.xdr == 2:
-                pin_o0 = get_o_inverter(pin.o0, o_invert)
-                pin_o1 = get_o_inverter(pin.o1, o_invert)
+                pin_o0 = get_oxor(pin.o0, o_invert)
+                pin_o1 = get_oxor(pin.o1, o_invert)
 
         if "i" in pin.dir and pin.xdr == 2:
             i0_ff = Signal.like(pin_i0, name_suffix="_ff")

--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -156,7 +156,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                     o_Q=q[bit]
                 )
 
-        def get_i_inverter(y, invert):
+        def get_ixor(y, invert):
             if invert is None:
                 return y
             else:
@@ -169,7 +169,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                     )
                 return a
 
-        def get_o_inverter(a, invert):
+        def get_oxor(a, invert):
             if invert is None:
                 return a
             else:
@@ -184,28 +184,32 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
 
         if "i" in pin.dir:
             if pin.xdr < 2:
-                pin_i = get_i_inverter(pin.i, i_invert)
+                pin_i  = get_ixor(pin.i, i_invert)
             elif pin.xdr == 2:
-                pin_i0 = get_i_inverter(pin.i0, i_invert)
-                pin_i1 = get_i_inverter(pin.i1, i_invert)
+                pin_i0 = get_ixor(pin.i0, i_invert)
+                pin_i1 = get_ixor(pin.i1, i_invert)
         if "o" in pin.dir:
             if pin.xdr < 2:
-                pin_o = get_o_inverter(pin.o, o_invert)
+                pin_o  = get_oxor(pin.o, o_invert)
             elif pin.xdr == 2:
-                pin_o0 = get_o_inverter(pin.o0, o_invert)
-                pin_o1 = get_o_inverter(pin.o1, o_invert)
+                pin_o0 = get_oxor(pin.o0, o_invert)
+                pin_o1 = get_oxor(pin.o1, o_invert)
 
-        i = Signal(pin.width, name="{}_xdr_i".format(pin.name))
-        o = Signal(pin.width, name="{}_xdr_o".format(pin.name))
-        t = Signal(1,         name="{}_xdr_t".format(pin.name))
+        i = o = t = None
+        if "i" in pin.dir:
+            i = Signal(pin.width, name="{}_xdr_i".format(pin.name))
+        if "o" in pin.dir:
+            o = Signal(pin.width, name="{}_xdr_o".format(pin.name))
+        if pin.dir in ("oe", "io"):
+            t = Signal(1,         name="{}_xdr_t".format(pin.name))
 
         if pin.xdr == 0:
             if "i" in pin.dir:
-                m.d.comb += pin_i.eq(i)
+                i = pin_i
             if "o" in pin.dir:
-                m.d.comb += o.eq(pin_o)
+                o = pin_o
             if pin.dir in ("oe", "io"):
-                m.d.comb += t.eq(~pin.oe)
+                t = ~pin.oe
         elif pin.xdr == 1:
             if "i" in pin.dir:
                 get_dff(pin.i_clk, i, pin_i)

--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -195,9 +195,9 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                 pin_o0 = get_o_inverter(pin.o0, o_invert)
                 pin_o1 = get_o_inverter(pin.o1, o_invert)
 
-        i  = Signal(pin.width, name="{}_xdr_i".format(pin.name))
-        o  = Signal(pin.width, name="{}_xdr_o".format(pin.name))
-        oe = Signal(1,         name="{}_xdr_oe".format(pin.name))
+        i = Signal(pin.width, name="{}_xdr_i".format(pin.name))
+        o = Signal(pin.width, name="{}_xdr_o".format(pin.name))
+        t = Signal(1,         name="{}_xdr_t".format(pin.name))
 
         if pin.xdr == 0:
             if "i" in pin.dir:
@@ -205,31 +205,31 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
             if "o" in pin.dir:
                 m.d.comb += o.eq(pin_o)
             if pin.dir in ("oe", "io"):
-                m.d.comb += oe.eq(pin.oe)
+                m.d.comb += t.eq(~pin.oe)
         elif pin.xdr == 1:
             if "i" in pin.dir:
                 get_dff(pin.i_clk, i, pin_i)
             if "o" in pin.dir:
                 get_dff(pin.o_clk, pin_o, o)
             if pin.dir in ("oe", "io"):
-                get_dff(pin.o_clk, pin.oe, oe)
+                get_dff(pin.o_clk, ~pin.oe, t)
         elif pin.xdr == 2:
             if "i" in pin.dir:
                 get_iddr(pin.i_clk, i, pin_i0, pin_i1)
             if "o" in pin.dir:
                 get_oddr(pin.o_clk, pin_o0, pin_o1, o)
             if pin.dir in ("oe", "io"):
-                get_dff(pin.o_clk, pin.oe, oe)
+                get_dff(pin.o_clk, ~pin.oe, t)
         else:
             assert False
 
-        return (i, o, oe)
+        return (i, o, t)
 
     def get_input(self, pin, port, attrs, invert):
         self._check_feature("single-ended input", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        i, o, oe = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
+        i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
         m.d.comb += i.eq(port)
         return m
 
@@ -237,7 +237,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         self._check_feature("single-ended output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        i, o, oe = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
+        i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         m.d.comb += port.eq(o)
         return m
 
@@ -245,10 +245,10 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         self._check_feature("single-ended tristate", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        i, o, oe = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
+        i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(port)):
             m.submodules += Instance("OBUFT",
-                i_T=~oe,
+                i_T=t,
                 i_I=o[bit],
                 o_O=port[bit]
             )
@@ -258,11 +258,11 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         self._check_feature("single-ended input/output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        i, o, oe = self._get_xdr_buffer(m, pin, i_invert=True if invert else None,
-                                                o_invert=True if invert else None)
+        i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None,
+                                               o_invert=True if invert else None)
         for bit in range(len(port)):
             m.submodules += Instance("IOBUF",
-                i_T=~oe,
+                i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
                 io_IO=port[bit]
@@ -273,7 +273,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         self._check_feature("differential input", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        i, o, oe = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
+        i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
         for bit in range(len(p_port)):
             m.submodules += Instance("IBUFDS",
                 i_I=p_port[bit], i_IB=n_port[bit],
@@ -285,7 +285,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         self._check_feature("differential output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        i, o, oe = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
+        i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(p_port)):
             m.submodules += Instance("OBUFDS",
                 i_I=o[bit],
@@ -297,10 +297,10 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         self._check_feature("differential tristate", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        i, o, oe = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
+        i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(p_port)):
             m.submodules += Instance("OBUFTDS",
-                i_T=~oe,
+                i_T=t,
                 i_I=o[bit],
                 o_O=p_port[bit], o_OB=n_port[bit]
             )
@@ -310,11 +310,11 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         self._check_feature("differential input/output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        i, o, oe = self._get_xdr_buffer(m, pin, i_invert=True if invert else None,
-                                                o_invert=True if invert else None)
+        i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None,
+                                               o_invert=True if invert else None)
         for bit in range(len(p_port)):
             m.submodules += Instance("IOBUFDS",
-                i_T=~oe,
+                i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
                 io_IO=p_port[bit], io_IOB=n_port[bit]

--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -234,7 +234,11 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
-        m.d.comb += i.eq(port)
+        for bit in range(len(port)):
+            m.submodules += Instance("IBUF",
+                i_I=port[bit],
+                o_O=i[bit]
+            )
         return m
 
     def get_output(self, pin, port, attrs, invert):
@@ -242,7 +246,11 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
-        m.d.comb += port.eq(o)
+        for bit in range(len(port)):
+            m.submodules += Instance("OBUF",
+                i_I=o[bit],
+                o_O=port[bit]
+            )
         return m
 
     def get_tristate(self, pin, port, attrs, invert):

--- a/nmigen/vendor/xilinx_spartan6.py
+++ b/nmigen/vendor/xilinx_spartan6.py
@@ -167,7 +167,7 @@ class XilinxSpartan6Platform(TemplatedPlatform):
                     o_Q=q[bit]
                 )
 
-        def get_i_inverter(y, invert):
+        def get_ixor(y, invert):
             if invert is None:
                 return y
             else:
@@ -180,7 +180,7 @@ class XilinxSpartan6Platform(TemplatedPlatform):
                     )
                 return a
 
-        def get_o_inverter(a, invert):
+        def get_oxor(a, invert):
             if invert is None:
                 return a
             else:
@@ -195,28 +195,32 @@ class XilinxSpartan6Platform(TemplatedPlatform):
 
         if "i" in pin.dir:
             if pin.xdr < 2:
-                pin_i = get_i_inverter(pin.i, i_invert)
+                pin_i  = get_ixor(pin.i, i_invert)
             elif pin.xdr == 2:
-                pin_i0 = get_i_inverter(pin.i0, i_invert)
-                pin_i1 = get_i_inverter(pin.i1, i_invert)
+                pin_i0 = get_ixor(pin.i0, i_invert)
+                pin_i1 = get_ixor(pin.i1, i_invert)
         if "o" in pin.dir:
             if pin.xdr < 2:
-                pin_o = get_o_inverter(pin.o, o_invert)
+                pin_o  = get_oxor(pin.o, o_invert)
             elif pin.xdr == 2:
-                pin_o0 = get_o_inverter(pin.o0, o_invert)
-                pin_o1 = get_o_inverter(pin.o1, o_invert)
+                pin_o0 = get_oxor(pin.o0, o_invert)
+                pin_o1 = get_oxor(pin.o1, o_invert)
 
-        i = Signal(pin.width, name="{}_xdr_i".format(pin.name))
-        o = Signal(pin.width, name="{}_xdr_o".format(pin.name))
-        t = Signal(1,         name="{}_xdr_t".format(pin.name))
+        i = o = t = None
+        if "i" in pin.dir:
+            i = Signal(pin.width, name="{}_xdr_i".format(pin.name))
+        if "o" in pin.dir:
+            o = Signal(pin.width, name="{}_xdr_o".format(pin.name))
+        if pin.dir in ("oe", "io"):
+            t = Signal(1,         name="{}_xdr_t".format(pin.name))
 
         if pin.xdr == 0:
             if "i" in pin.dir:
-                m.d.comb += pin_i.eq(i)
+                i = pin_i
             if "o" in pin.dir:
-                m.d.comb += o.eq(pin_o)
+                o = pin_o
             if pin.dir in ("oe", "io"):
-                m.d.comb += t.eq(~pin.oe)
+                t = ~pin.oe
         elif pin.xdr == 1:
             if "i" in pin.dir:
                 get_dff(pin.i_clk, i, pin_i)

--- a/nmigen/vendor/xilinx_spartan6.py
+++ b/nmigen/vendor/xilinx_spartan6.py
@@ -249,7 +249,11 @@ class XilinxSpartan6Platform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
-        m.d.comb += i.eq(port)
+        for bit in range(len(port)):
+            m.submodules += Instance("IBUF",
+                i_I=port[bit],
+                o_O=i[bit]
+            )
         return m
 
     def get_output(self, pin, port, attrs, invert):
@@ -257,7 +261,11 @@ class XilinxSpartan6Platform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
-        m.d.comb += port.eq(o)
+        for bit in range(len(port)):
+            m.submodules += Instance("OBUF",
+                i_I=o[bit],
+                o_O=port[bit]
+            )
         return m
 
     def get_tristate(self, pin, port, attrs, invert):


### PR DESCRIPTION
@jfng Can you please review this, and make sure I didn't break anything? The main part here is the commit that removes the inverter between the register (FDCE) and tristate input of the IOB. The rest is just misc cleanups that remove intermediate signals and ensure that if a pin doesn't have e.g. the `i` signal, there is no `i` signal returned from `_get_xdr_buffer`.