### PR TITLE
vendor.xilinx_7series: read extra .xdc files.

### DIFF
--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -62,6 +62,11 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
             {% endfor %}
             add_files {{name}}.v
             read_xdc {{name}}.xdc
+            {% for file in platform.extra_files %}
+                {% if file.endswith("xdc") -%}
+                    read_xdc {{file}}
+                {% endif %}
+            {% endfor %}
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
             synth_design -top {{name}} -part {{platform.device}}{{platform.package}}-{{platform.speed}}
             {{get_override("script_after_synth")|default("# (script_after_synth placeholder)")}}


### PR DESCRIPTION
I'm not quite sure if this is correct in general but I expect *.xdc* constraint extra files to be applied. This patch filters `extra_files` for `.xdc` endings and applies them using `read_xdc`. 