### PR TITLE
build.dsl: Add optional name_suffix to Resource.family.

### DIFF
--- a/nmigen/build/dsl.py
+++ b/nmigen/build/dsl.py
@@ -182,7 +182,7 @@ class Subsignal:
 
 class Resource(Subsignal):
     @classmethod
-    def family(cls, name_or_number, number=None, *, ios, default_name):
+    def family(cls, name_or_number, number=None, *, ios, default_name, name_suffix=""):
         # This constructor accepts two different forms:
         #  1. Number-only form:
         #       Resource.family(0, default_name="name", ios=[Pins("A0 A1")])
@@ -190,10 +190,15 @@ class Resource(Subsignal):
         #       Resource.family("override", 0, default_name="name", ios=...)
         # This makes it easier to build abstractions for resources, e.g. an SPIResource abstraction
         # could simply delegate to `Resource.family(*args, default_name="spi", ios=ios)`.
+        # The name_suffix argument is meant to support creating resources with
+        # similar names, such as spi_flash, spi_flash_2x, etc.
+        if name_suffix:  # Only add "_" if we actually have a suffix.
+            name_suffix = "_" + name_suffix
+
         if number is None: # name_or_number is number
-            return cls(default_name, name_or_number, *ios)
+            return cls(default_name + name_suffix, name_or_number, *ios)
         else: # name_or_number is name
-            return cls(name_or_number, number, *ios)
+            return cls(name_or_number + name_suffix, number, *ios)
 
     def __init__(self, name, number, *args):
         super().__init__(name, *args)

--- a/nmigen/test/test_build_dsl.py
+++ b/nmigen/test/test_build_dsl.py
@@ -229,10 +229,16 @@ class ResourceTestCase(FHDLTestCase):
         ios = [Subsignal("clk", Pins("A0", dir="o"))]
         r1  = Resource.family(0, default_name="spi", ios=ios)
         r2  = Resource.family("spi_flash", 0, default_name="spi", ios=ios)
+        r3  = Resource.family("spi_flash", 0, default_name="spi", ios=ios, name_suffix="4x")
+        r4  = Resource.family(0, default_name="spi", ios=ios, name_suffix="2x")
         self.assertEqual(r1.name, "spi")
         self.assertEqual(r1.ios, ios)
         self.assertEqual(r2.name, "spi_flash")
         self.assertEqual(r2.ios, ios)
+        self.assertEqual(r3.name, "spi_flash_4x")
+        self.assertEqual(r3.ios, ios)
+        self.assertEqual(r4.name, "spi_2x")
+        self.assertEqual(r4.ios, ios)
 
 
 class ConnectorTestCase(FHDLTestCase):


### PR DESCRIPTION
Just as `Resource.family` makes it easier to generate `Resources` with a fallback name, this PR makes it easier to support `Resources` in `nmigen_boards` that only differ in features and should have identical prefixes names, such as SPI flashes with different widths.