### PR TITLE
build.run: Ensure batch script returns proper error code.

### DIFF
--- a/nmigen/build/run.py
+++ b/nmigen/build/run.py
@@ -71,7 +71,13 @@ class BuildPlan:
 
             if run_script:
                 if sys.platform.startswith("win32"):
-                    subprocess.check_call(["cmd", "/c", "{}.bat".format(self.script)])
+                    # Without "call", "cmd /c {}.bat" will return 0.
+                    # See https://stackoverflow.com/a/30736987 for a detailed
+                    # explanation of why, including disassembly/decompilation
+                    # of relevant code in cmd.exe.
+                    # Running the script manually from a command prompt is
+                    # unaffected- i.e. "call" is not required.
+                    subprocess.check_call(["cmd", "/c", "call {}.bat".format(self.script)])
                 else:
                     subprocess.check_call(["sh", "{}.sh".format(self.script)])
 


### PR DESCRIPTION
The Windows command line is a mess.

When trying to synthesize some `nmigen` code today, I ran into a `nextpnr` problem that caused the whole build to fail. The batch script correctly exited early, but `CalledProcessError` was never raised (meaning return code from `check_call` was `0`). Since I had `do_program=True`, `plat.build` continued, and this cascaded into more errors:

```
William@WILLIAM-THINK C:\msys64\home\William\src\icebreaker-nmigen-examples\pdm_fade_gamma
> python3 gamma_pdm.py
ERROR: Top-level input 'I0' also driven by I0.O.
ERROR: Loading design failed.
0 warnings, 2 errors
Traceback (most recent call last):
  File "C:\msys64\home\william\src\nmigen\nmigen\build\run.py", line 120, in extract
    file.write(self.get(filename))
  File "C:\msys64\home\william\src\nmigen\nmigen\build\run.py", line 143, in get
    with open(os.path.join(self.__root, filename), "r" + mode) as f:
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\msys64\\home\\William\\src\\icebreaker-nmigen-examples\\pdm_fade_gamma\\build\\top.bin'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "gamma_pdm.py", line 169, in <module>
    plat.build(Top(), do_program=True)
  File "C:\msys64\home\william\src\nmigen\nmigen\build\plat.py", line 55, in build
    self.toolchain_program(products, name, **(program_opts or {}))
  File "C:\msys64\home\william\src\nmigen-boards\nmigen_boards\icebreaker.py", line 80, in toolchain_program
    with products.extract("{}.bin".format(name)) as bitstream_filename:
  File "C:\msys64\mingw64\lib\python3.7\contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "C:\msys64\home\william\src\nmigen\nmigen\build\run.py", line 131, in extract
    os.unlink(file.name)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\William\\AppData\\Local\\Temp\\nmigen_q17qki6z_top.bin'
```

After doing some research, I found prepending `call` to the batch file command fixes this error. This [SO answer](https://stackoverflow.com/questions/30714985/how-to-properly-report-an-exit-status-in-batch/30736987#30736987) goes into detail about how rather screwed up error code returning is on Windows, and is based on someone's assembly-level (!) debugging of `cmd.exe`.

With this patch, and with nothing else changes, `nmigen` now raises `CalledProcessError` if the batch script fails:

```
William@WILLIAM-THINK C:\msys64\home\William\src\icebreaker-nmigen-examples\pdm_fade_gamma
> python3 gamma_pdm.py
ERROR: Top-level input 'I0' also driven by I0.O.
ERROR: Loading design failed.
0 warnings, 2 errors
Traceback (most recent call last):
  File "gamma_pdm.py", line 169, in <module>
    plat.build(Top(), do_program=True)
  File "C:\msys64\home\william\src\nmigen\nmigen\build\plat.py", line 51, in build
    products = plan.execute_local(build_dir)
  File "C:\msys64\home\william\src\nmigen\nmigen\build\run.py", line 74, in execute_local
    subprocess.check_call(["cmd", "/c", "call {}.bat".format(self.script)])
  File "C:\msys64\mingw64\lib\python3.7\subprocess.py", line 347, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmd', '/c', 'call build_top.bat']' returned non-zero exit status 4294967295.
```


