### PR TITLE
add getters to m.submodules

### DIFF
--- a/nmigen/hdl/dsl.py
+++ b/nmigen/hdl/dsl.py
@@ -429,7 +429,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
             self._anon_submodules.append(submodule)
         else:
             if name in self._named_submodules:
-                raise ValueError("Submodule named '{}' already exists".format(name))
+                raise NameError("Submodule named '{}' already exists".format(name))
             self._named_submodules[name] = submodule
 
     def _get_submodule(self, name):

--- a/nmigen/hdl/dsl.py
+++ b/nmigen/hdl/dsl.py
@@ -87,6 +87,12 @@ class _ModuleBuilderSubmodules:
     def __setitem__(self, name, value):
         return self.__setattr__(name, value)
 
+    def __getattr__(self, name):
+        return self._builder._get_submodule(name)
+
+    def __getitem__(self, name):
+        return self.__getattr__(name)
+
 
 class _ModuleBuilderDomainSet:
     def __init__(self, builder):
@@ -124,7 +130,8 @@ class Module(_ModuleBuilderRoot, Elaboratable):
         self._ctrl_stack   = []
 
         self._driving      = SignalDict()
-        self._submodules   = []
+        self._submodules   = {}
+        self._anon_submodules = []
         self._domains      = []
         self._generated    = {}
 
@@ -418,7 +425,18 @@ class Module(_ModuleBuilderRoot, Elaboratable):
         if not hasattr(submodule, "elaborate"):
             raise TypeError("Trying to add '{!r}', which does not implement .elaborate(), as "
                             "a submodule".format(submodule))
-        self._submodules.append((submodule, name))
+        if name == None:
+            self._anon_submodules.append(submodule)
+        else:
+            if name in self._submodules:
+                raise ValueError("Submodule named '{}' already exists".format(name))
+            self._submodules[name] = submodule
+
+    def _get_submodule(self, name):
+        if name in self._submodules:
+            return self._submodules[name]
+        else:
+            raise AttributeError("No submodule named '{}' exists".format(name))
 
     def _add_domain(self, cd):
         self._domains.append(cd)
@@ -431,8 +449,10 @@ class Module(_ModuleBuilderRoot, Elaboratable):
         self._flush()
 
         fragment = Fragment()
-        for submodule, name in self._submodules:
-            fragment.add_subfragment(Fragment.get(submodule, platform), name)
+        for name in self._submodules:
+            fragment.add_subfragment(Fragment.get(self._submodules[name], platform), name)
+        for submodule in self._anon_submodules:
+            fragment.add_subfragment(Fragment.get(submodule, platform), None)
         statements = SampleDomainInjector("sync")(self._statements)
         fragment.add_statements(statements)
         for signal, domain in self._driving.items():

--- a/nmigen/hdl/dsl.py
+++ b/nmigen/hdl/dsl.py
@@ -130,7 +130,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
         self._ctrl_stack   = []
 
         self._driving      = SignalDict()
-        self._submodules   = {}
+        self._named_submodules   = {}
         self._anon_submodules = []
         self._domains      = []
         self._generated    = {}
@@ -428,13 +428,13 @@ class Module(_ModuleBuilderRoot, Elaboratable):
         if name == None:
             self._anon_submodules.append(submodule)
         else:
-            if name in self._submodules:
+            if name in self._named_submodules:
                 raise ValueError("Submodule named '{}' already exists".format(name))
-            self._submodules[name] = submodule
+            self._named_submodules[name] = submodule
 
     def _get_submodule(self, name):
-        if name in self._submodules:
-            return self._submodules[name]
+        if name in self._named_submodules:
+            return self._named_submodules[name]
         else:
             raise AttributeError("No submodule named '{}' exists".format(name))
 
@@ -449,8 +449,8 @@ class Module(_ModuleBuilderRoot, Elaboratable):
         self._flush()
 
         fragment = Fragment()
-        for name in self._submodules:
-            fragment.add_subfragment(Fragment.get(self._submodules[name], platform), name)
+        for name in self._named_submodules:
+            fragment.add_subfragment(Fragment.get(self._named_submodules[name], platform), name)
         for submodule in self._anon_submodules:
             fragment.add_subfragment(Fragment.get(submodule, platform), None)
         statements = SampleDomainInjector("sync")(self._statements)

--- a/nmigen/test/test_hdl_dsl.py
+++ b/nmigen/test/test_hdl_dsl.py
@@ -555,7 +555,7 @@ class DSLTestCase(FHDLTestCase):
         m1 = Module()
         m2 = Module()
         m1.submodules.foo = m2
-        with self.assertRaises(ValueError, msg="Submodule named 'foo' already exists"):
+        with self.assertRaises(NameError, msg="Submodule named 'foo' already exists"):
             m1.submodules.foo = m2
 
     def test_submodule_get(self):

--- a/nmigen/test/test_hdl_dsl.py
+++ b/nmigen/test/test_hdl_dsl.py
@@ -518,7 +518,7 @@ class DSLTestCase(FHDLTestCase):
         m2 = Module()
         m1.submodules += m2
         self.assertEqual(m1._anon_submodules, [m2])
-        self.assertEqual(m1._submodules, {})
+        self.assertEqual(m1._named_submodules, {})
 
     def test_submodule_anon_multi(self):
         m1 = Module()
@@ -526,21 +526,21 @@ class DSLTestCase(FHDLTestCase):
         m3 = Module()
         m1.submodules += m2, m3
         self.assertEqual(m1._anon_submodules, [m2, m3])
-        self.assertEqual(m1._submodules, {})
+        self.assertEqual(m1._named_submodules, {})
 
     def test_submodule_named(self):
         m1 = Module()
         m2 = Module()
         m1.submodules.foo = m2
         self.assertEqual(m1._anon_submodules, [])
-        self.assertEqual(m1._submodules, {"foo": m2})
+        self.assertEqual(m1._named_submodules, {"foo": m2})
 
     def test_submodule_named_index(self):
         m1 = Module()
         m2 = Module()
         m1.submodules["foo"] = m2
         self.assertEqual(m1._anon_submodules, [])
-        self.assertEqual(m1._submodules, {"foo": m2})
+        self.assertEqual(m1._named_submodules, {"foo": m2})
 
     def test_submodule_wrong(self):
         m = Module()

--- a/nmigen/test/test_hdl_dsl.py
+++ b/nmigen/test/test_hdl_dsl.py
@@ -517,26 +517,30 @@ class DSLTestCase(FHDLTestCase):
         m1 = Module()
         m2 = Module()
         m1.submodules += m2
-        self.assertEqual(m1._submodules, [(m2, None)])
+        self.assertEqual(m1._anon_submodules, [m2])
+        self.assertEqual(m1._submodules, {})
 
     def test_submodule_anon_multi(self):
         m1 = Module()
         m2 = Module()
         m3 = Module()
         m1.submodules += m2, m3
-        self.assertEqual(m1._submodules, [(m2, None), (m3, None)])
+        self.assertEqual(m1._anon_submodules, [m2, m3])
+        self.assertEqual(m1._submodules, {})
 
     def test_submodule_named(self):
         m1 = Module()
         m2 = Module()
         m1.submodules.foo = m2
-        self.assertEqual(m1._submodules, [(m2, "foo")])
+        self.assertEqual(m1._anon_submodules, [])
+        self.assertEqual(m1._submodules, {"foo": m2})
 
     def test_submodule_named_index(self):
         m1 = Module()
         m2 = Module()
         m1.submodules["foo"] = m2
-        self.assertEqual(m1._submodules, [(m2, "foo")])
+        self.assertEqual(m1._anon_submodules, [])
+        self.assertEqual(m1._submodules, {"foo": m2})
 
     def test_submodule_wrong(self):
         m = Module()
@@ -546,6 +550,34 @@ class DSLTestCase(FHDLTestCase):
         with self.assertRaises(TypeError,
                 msg="Trying to add '1', which does not implement .elaborate(), as a submodule"):
             m.submodules += 1
+
+    def test_submodule_named_conflict(self):
+        m1 = Module()
+        m2 = Module()
+        m1.submodules.foo = m2
+        with self.assertRaises(ValueError, msg="Submodule named 'foo' already exists"):
+            m1.submodules.foo = m2
+
+    def test_submodule_get(self):
+        m1 = Module()
+        m2 = Module()
+        m1.submodules.foo = m2
+        m3 = m1.submodules.foo
+        self.assertEqual(m2, m3)
+
+    def test_submodule_get_index(self):
+        m1 = Module()
+        m2 = Module()
+        m1.submodules["foo"] = m2
+        m3 = m1.submodules["foo"]
+        self.assertEqual(m2, m3)
+
+    def test_submodule_get_unset(self):
+        m1 = Module()
+        with self.assertRaises(AttributeError, msg="No submodule named 'foo' exists"):
+            m2 = m1.submodules.foo
+        with self.assertRaises(AttributeError, msg="No submodule named 'foo' exists"):
+            m2 = m1.submodules["foo"]
 
     def test_domain_named_implicit(self):
         m = Module()


### PR DESCRIPTION
This allows retrieving a named submodule after assigning it:
```
>>> m1 = Module()
>>> m1.submodules.m2 = Module()
>>> m1.submodules.m2
<nmigen.hdl.dsl.Module object at 0x7f2acc2cf240>
```

It also disallows setting the same submodule name twice:
```
>>> m1 = Module()
>>> m1.submodules.m2 = Module()
>>> m1.submodules.m2 = Module()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/nengel/nmigen/nmigen/hdl/dsl.py", line 85, in __setattr__
    self._builder._add_submodule(submodule, name)
  File "/home/nengel/nmigen/nmigen/hdl/dsl.py", line 432, in _add_submodule
    raise ValueError("Submodule named '{}' already exists".format(name))
ValueError: Submodule named 'm2' already exists
```

Item notation is also supported:
```
>>> m1 = Module()
>>> m1.submodules['m2'] = Module()
>>> m1.submodules['m2']
<nmigen.hdl.dsl.Module object at 0x7f52834464a8>
>>> m1.submodules.m2
<nmigen.hdl.dsl.Module object at 0x7f52834464a8>
```