### PR TITLE
remove duplicate iobuf submodule names

### DIFF
--- a/nmigen/vendor/lattice_ecp5.py
+++ b/nmigen/vendor/lattice_ecp5.py
@@ -272,7 +272,7 @@ class LatticeECP5Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("IB",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("IB",
                 i_I=port[bit],
                 o_O=i[bit]
             )
@@ -284,7 +284,7 @@ class LatticeECP5Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("OB",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OB",
                 i_I=o[bit],
                 o_O=port[bit]
             )
@@ -296,7 +296,7 @@ class LatticeECP5Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("OBZ",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBZ",
                 i_T=t,
                 i_I=o[bit],
                 o_O=port[bit]
@@ -310,7 +310,7 @@ class LatticeECP5Platform(TemplatedPlatform):
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None,
                                                o_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("BB",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("BB",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
@@ -324,7 +324,7 @@ class LatticeECP5Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("IB",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("IB",
                 i_I=p_port[bit],
                 o_O=i[bit]
             )
@@ -336,7 +336,7 @@ class LatticeECP5Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("OB",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OB",
                 i_I=o[bit],
                 o_O=p_port[bit],
             )
@@ -348,7 +348,7 @@ class LatticeECP5Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("OBZ",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBZ",
                 i_T=t,
                 i_I=o[bit],
                 o_O=p_port[bit],
@@ -362,7 +362,7 @@ class LatticeECP5Platform(TemplatedPlatform):
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None,
                                                o_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("BB",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("BB",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],

--- a/nmigen/vendor/lattice_ice40.py
+++ b/nmigen/vendor/lattice_ice40.py
@@ -253,9 +253,9 @@ class LatticeICE40Platform(TemplatedPlatform):
                 io_args.append(("i", "OUTPUT_ENABLE", pin.oe))
 
             if is_global_input:
-                m.submodules[pin.name] = Instance("SB_GB_IO", *io_args)
+                m.submodules["{}_{}".format(pin.name, bit)] = Instance("SB_GB_IO", *io_args)
             else:
-                m.submodules[pin.name] = Instance("SB_IO", *io_args)
+                m.submodules["{}_{}".format(pin.name, bit)] = Instance("SB_IO", *io_args)
 
     def get_input(self, pin, port, attrs, invert):
         self._check_feature("single-ended input", pin, attrs,

--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -245,7 +245,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("IBUF",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("IBUF",
                 i_I=port[bit],
                 o_O=i[bit]
             )
@@ -257,7 +257,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("OBUF",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUF",
                 i_I=o[bit],
                 o_O=port[bit]
             )
@@ -269,7 +269,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("OBUFT",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFT",
                 i_T=t,
                 i_I=o[bit],
                 o_O=port[bit]
@@ -283,7 +283,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None,
                                                o_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("IOBUF",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("IOBUF",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
@@ -297,7 +297,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("IBUFDS",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("IBUFDS",
                 i_I=p_port[bit], i_IB=n_port[bit],
                 o_O=i[bit]
             )
@@ -309,7 +309,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("OBUFDS",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFDS",
                 i_I=o[bit],
                 o_O=p_port[bit], o_OB=n_port[bit]
             )
@@ -321,7 +321,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("OBUFTDS",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFTDS",
                 i_T=t,
                 i_I=o[bit],
                 o_O=p_port[bit], o_OB=n_port[bit]
@@ -335,7 +335,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None,
                                                o_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("IOBUFDS",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("IOBUFDS",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],

--- a/nmigen/vendor/xilinx_spartan_3_6.py
+++ b/nmigen/vendor/xilinx_spartan_3_6.py
@@ -283,7 +283,7 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("IBUF",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("IBUF",
                 i_I=port[bit],
                 o_O=i[bit]
             )
@@ -295,7 +295,7 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("OBUF",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUF",
                 i_I=o[bit],
                 o_O=port[bit]
             )
@@ -307,7 +307,7 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("OBUFT",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFT",
                 i_T=t,
                 i_I=o[bit],
                 o_O=port[bit]
@@ -321,7 +321,7 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None,
                                                o_invert=True if invert else None)
         for bit in range(len(port)):
-            m.submodules[pin.name] = Instance("IOBUF",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("IOBUF",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
@@ -335,7 +335,7 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("IBUFDS",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("IBUFDS",
                 i_I=p_port[bit], i_IB=n_port[bit],
                 o_O=i[bit]
             )
@@ -347,7 +347,7 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("OBUFDS",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFDS",
                 i_I=o[bit],
                 o_O=p_port[bit], o_OB=n_port[bit]
             )
@@ -359,7 +359,7 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("OBUFTDS",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFTDS",
                 i_T=t,
                 i_I=o[bit],
                 o_O=p_port[bit], o_OB=n_port[bit]
@@ -373,7 +373,7 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=True if invert else None,
                                                o_invert=True if invert else None)
         for bit in range(len(p_port)):
-            m.submodules[pin.name] = Instance("IOBUFDS",
+            m.submodules["{}_{}".format(pin.name, bit)] = Instance("IOBUFDS",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],


### PR DESCRIPTION
Fixes #157.

Vendor files create a lot of IObufs with duplicate names:
```for bit in range(len(port)):
    m.submodules[pin.name] = Instance(...)
```
which is no longer allowed as of 698b005.

This appends a suffix for each bit:
```
for bit in range(len(p_port)):
    m.submodules["{}_{}".format(pin.name, bit)] = Instance(...)
```