### PR TITLE
Specific error message for missing module return from 'elaborate'.

### DIFF
--- a/nmigen/hdl/ir.py
+++ b/nmigen/hdl/ir.py
@@ -67,7 +67,10 @@ class Fragment:
                     stacklevel=2)
                 obj = obj.elaborate(platform)
             else:
-                raise AttributeError("Object '{!r}' cannot be elaborated".format(obj))
+                if obj is not None:
+                    raise AttributeError("Object '{!r}' cannot be elaborated".format(obj))
+                else:
+                    raise AttributeError("Object '{!r}' cannot be elaborated. Possible root cause: perhaps 'elaborate' doesn't return a module?".format(obj))
 
     def __init__(self):
         self.ports = SignalDict()

--- a/nmigen/test/test_hdl_ir.py
+++ b/nmigen/test/test_hdl_ir.py
@@ -10,7 +10,7 @@ from .tools import *
 class FragmentGetTestCase(FHDLTestCase):
     def test_get_wrong(self):
         with self.assertRaises(AttributeError,
-                msg="Object 'None' cannot be elaborated"):
+                msg="Object 'None' cannot be elaborated. Possible root cause: perhaps 'elaborate' doesn't return a module?"):
             Fragment.get(None, platform=None)
 
 


### PR DESCRIPTION
As a beginner, I made this mistake a few times, when I was commenting things in and out from my 'elaborate' functions. When I forgot to return a module from 'elaborate', I got the error 'AttributeError: Object 'None' cannot be elaborated.', which threw me off initially. Perhaps this can help other beginners to locate the problem quickly.