### PR TITLE
test.test_examples: Convert pathlib-specific class to string.

### DIFF
--- a/nmigen/test/test_examples.py
+++ b/nmigen/test/test_examples.py
@@ -8,7 +8,7 @@ from .tools import *
 def example_test(name):
     path = (Path(__file__).parent / ".." / ".." / "examples" / name).resolve()
     def test_function(self):
-        subprocess.check_call([sys.executable, path, "generate"], stdout=subprocess.DEVNULL)
+        subprocess.check_call([sys.executable, str(path), "generate"], stdout=subprocess.DEVNULL)
     return test_function
 
 


### PR DESCRIPTION
`subprocess.check_call` iterates over its arguments to check for spaces and tabs, and on Windows, the pathlib-specific WindowsPath is not iterable.

Before this change, the all tests in `test_examples.py` would fail with an error like this:

```
William@William-THINK MINGW64 ~/src/nmigen
$ python3 -m unittest
..............................................................................................EEEEEEEEEEEEE..........................................................................................................................................................................................................................................................................................................................................................
======================================================================
ERROR: test_alu (nmigen.test.test_examples.ExamplesTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:/msys64/home/William/src/nmigen\nmigen\test\test_examples.py", line 11, in test_function
    subprocess.check_call([sys.executable, path, "generate"], stdout=subprocess.DEVNULL)
  File "C:/msys64/mingw64/lib/python3.7\subprocess.py", line 342, in check_call
    retcode = call(*popenargs, **kwargs)
  File "C:/msys64/mingw64/lib/python3.7\subprocess.py", line 323, in call
    with Popen(*popenargs, **kwargs) as p:
  File "C:/msys64/mingw64/lib/python3.7\subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "C:/msys64/mingw64/lib/python3.7\subprocess.py", line 1119, in _execute_child
    args = list2cmdline(args)
  File "C:/msys64/mingw64/lib/python3.7\subprocess.py", line 530, in list2cmdline
    needquote = (" " in arg) or ("\t" in arg) or not arg
TypeError: argument of type 'WindowsPath' is not iterable
```

After this change, all tests pass successfully:

```
William@William-THINK MINGW64 ~/src/nmigen
$ python3 -m unittest
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 453 tests in 57.663s

OK
```