### PR TITLE
[DRAFT] Allow PULLUP=1 as a valid int attr value to re-enable yosys 0.9

### DIFF
--- a/nmigen/build/dsl.py
+++ b/nmigen/build/dsl.py
@@ -92,7 +92,7 @@ def DiffPairsN(*args, **kwargs):
 class Attrs(OrderedDict):
     def __init__(self, **attrs):
         for key, value in attrs.items():
-            if not (value is None or isinstance(value, str) or hasattr(value, "__call__")):
+            if not (value is None or isinstance(value, (str, int)) or hasattr(value, "__call__")):
                 raise TypeError("Value of attribute {} must be None, str, or callable, not {!r}"
                                 .format(key, value))
 
@@ -103,6 +103,8 @@ class Attrs(OrderedDict):
         for key, value in self.items():
             if value is None:
                 items.append("!" + key)
+            elif isinstance(value, int):
+                items.append(key + "=" + value)
             elif hasattr(value, "__call__"):
                 items.append(key + "=" + repr(value))
             else:

--- a/nmigen/test/test_build_dsl.py
+++ b/nmigen/test/test_build_dsl.py
@@ -124,10 +124,13 @@ class AttrsTestCase(FHDLTestCase):
         self.assertEqual(a["FOO"], fn)
         self.assertEqual(repr(a), "(attrs FOO={!r})".format(fn))
 
-    def test_wrong_value(self):
-        with self.assertRaises(TypeError,
-                msg="Value of attribute FOO must be None, str, or callable, not 1"):
-            a = Attrs(FOO=1)
+    # DRAFT - test no longer needed since 1 (int) would now be a valid value
+    # (needed in the context of PULLUP=1 in the UART board definition).
+    #
+    # def test_wrong_value(self):
+    #     with self.assertRaises(TypeError,
+    #         msg="Value of attribute FOO must be None, str, or callable, not 1"):
+    #         a = Attrs(FOO=1)
 
 
 class ClockTestCase(FHDLTestCase):


### PR DESCRIPTION
I'm having trouble getting the iCEBreaker UART to work with yosys 0.9 (PULLUP="1" causes downstream issue). See [this brief thread](https://github.com/YosysHQ/yosys/issues/1341) for the discussion with @daveshah1 for context. Specifically, I'm trying to change the `PULLUP="1"` to a numeric `PULLUP=1` in the nmigen-board definition. 
Easy. But, unless I make the associated change to how nMigen handles `Attrs` (this pull request proposal), I continue to get the string `.repr`, and not the numeric value in the `.il` file.

Would love your feedback on this change. Should make it possible to pass a numeric value for the PULLUP attribute to Yosys 0.9 and nextpnr. It may be the completely wrong place to address the challange, happy to learn!

```console
        ...
        UARTResource(0,
            rx="6", tx="9",
            attrs=Attrs(IO_STANDARD="SB_LVTTL", PULLUP=1)
        ),
	...
```

This change would make 1 (int) a valid attr value, which means the `test_build_dsl.test_wrong_value test`, which guards against `1` being valid, would no longer be needed.

The fact that I'm rendering a known test obsolete makes be suspicious that this may not be the right way of going addressing the root cause of the problem at all ;-)

Please view this pull request as a discussion starter. Appreciate guidance on how to solve this issue and how I can best help.
