### PR TITLE
pass ecppack_opts to ecppack

### DIFF
--- a/nmigen/vendor/lattice_ecp5.py
+++ b/nmigen/vendor/lattice_ecp5.py
@@ -148,6 +148,7 @@ class LatticeECP5Platform(TemplatedPlatform):
         r"""
         {{get_tool("ecppack")}}
             {{verbose("--verbose")}}
+            {{get_override("ecppack_opts")|options}}
             --input {{name}}.config
             --bit {{name}}.bit
             --svf {{name}}.svf


### PR DESCRIPTION
This was missing.

I needed this for passing `--idcode 0x21111043` [ref](https://github.com/SymbiFlow/prjtrellis/issues/55) which is required for LFE5U-12F. Not sure if that should be automatically added if that part is selected.