### PR TITLE
Accepts '?' in Case, maps to '-'

### DIFF
--- a/nmigen/hdl/dsl.py
+++ b/nmigen/hdl/dsl.py
@@ -273,6 +273,8 @@ class Module(_ModuleBuilderRoot, Elaboratable):
                               .format(value, len(switch_data["test"])),
                               SyntaxWarning, stacklevel=3)
                 continue
+            if isinstance(value, str):
+                value = value.replace("?", "-")
             new_values = (*new_values, value)
         try:
             _outer_case, self._statements = self._statements, []

--- a/nmigen/test/test_hdl_dsl.py
+++ b/nmigen/test/test_hdl_dsl.py
@@ -297,12 +297,15 @@ class DSLTestCase(FHDLTestCase):
                 m.d.comb += self.c1.eq(1)
             with m.Case("11--"):
                 m.d.comb += self.c2.eq(1)
+            with m.Case("10??"):
+                m.d.comb += self.c2.eq(1)
         m._flush()
         self.assertRepr(m._statements, """
         (
             (switch (sig w1)
                 (case 0011 (eq (sig c1) (const 1'd1)))
                 (case 11-- (eq (sig c2) (const 1'd1)))
+                (case 10-- (eq (sig c2) (const 1'd1)))
             )
         )
         """)


### PR DESCRIPTION
`-` is the don't-care value in IL, but `?` is the don't-care value in Verilog. This change allows you to use both in a Case.

Tested:
* Added test case
* Tested using this example, generating via `-t il` and `-t v` and inspecting output is well-formed:

```
from nmigen import *
from nmigen.cli import main
from nmigen.asserts import *


class TestCase(Elaboratable):
    def __init__(self):
        self.input = Signal(8)
        self.output = Signal()

    def elaborate(self, platform):
        m = Module()

        with m.Switch(self.input):
            with m.Case(0b00000000):
                m.d.comb += self.output.eq(1)
            with m.Case("1???0000"):
                m.d.comb += self.output.eq(0)
            with m.Default():
                m.d.comb += self.output.eq(1)
        return m


if __name__ == "__main__":
    clk = Signal()
    rst = Signal()

    pos = ClockDomain()
    pos.clk = clk
    pos.rst = rst

    testcase = TestCase()

    m = Module()
    m.domains.pos = pos
    m.submodules.testcase = testcase

    main(
        m,
        ports=[clk, rst, testcase.input, testcase.output],
        platform="formal")
```
