### PR TITLE
Adds Value.matches

### DIFF
--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -244,12 +244,11 @@ class Value(metaclass=ABCMeta):
 
         Parameters
         ----------
-        value : int or str or Const
-            The value to be matched against. If an integer or Const, then its
-            width in bits must be equal to or less than the width of this
-            ``Value``. If a string, then it must be a string of binary digits
-            (including `-` as the don't-care value) of the same width as this
-            ``Value``.
+        value : int or str
+            The value to be matched against. If an integer, then its width
+            in bits must be equal to or less than the width of this ``Value``.
+            If a string, then it must be a string of binary digits (including
+            `-` as the don't-care value) of the same width as this ``Value``.
 
         Returns
         -------
@@ -258,9 +257,7 @@ class Value(metaclass=ABCMeta):
         """
         n = len(self)
         if isinstance(value, int):
-            value = Const(value)
-        if isinstance(value, Const):
-            if len(value) > n:
+            if bits_for(value) > n:
                 warnings.warn("Match value '{:b}' is wider than matched (which has width {}); "
                               "comparison will never be true"
                               .format(value, n),

--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -254,9 +254,8 @@ class Value(metaclass=ABCMeta):
 
         Returns
         -------
-        Operator or int
-            The ``Operator`` representing the match if the length of ``*values``
-            is 1 or more, otherwise the integer `0`.
+        Operator
+            The ``Operator`` representing the match.
         """
         n = len(self)
         operations = []
@@ -279,11 +278,7 @@ class Value(metaclass=ABCMeta):
                 operations.append((self & mask) == comparand)
             else:
                 raise SyntaxError("matches() only accepts strings and integers")
-        if len(operations) == 0:
-            return 0
-        if len(operations) == 1:
-            return operations[0]
-        return functools.reduce(lambda x, y: x|y, operations[1:], operations[0])
+        return Cat(operations).any()
 
     @abstractmethod
     def shape(self):

--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 import builtins
+import functools
 import traceback
 import warnings
 from collections import OrderedDict
@@ -237,42 +238,52 @@ class Value(metaclass=ABCMeta):
         """
         return Assign(self, value, src_loc_at=1)
 
-    def matches(self, value):
+    def matches(self, *values):
         """Predicate for matching.
 
-        Matches the ``Value`` against the given value.
+        Matches the ``Value`` against any of the given values.
 
         Parameters
         ----------
-        value : int or str
-            The value to be matched against. If an integer, then its width
+        *values :
+            Variable length value list. Each value is an int or str, which is
+            a value to be matched against. If an integer, then its width
             in bits must be equal to or less than the width of this ``Value``.
             If a string, then it must be a string of binary digits (including
             `-` as the don't-care value) of the same width as this ``Value``.
 
         Returns
         -------
-        Operator
-            The ``Operator`` representing the match.
+        Operator or int
+            The ``Operator`` representing the match if the length of ``*values``
+            is 1 or more, otherwise the integer `0`.
         """
         n = len(self)
-        if isinstance(value, int):
-            if bits_for(value) > n:
-                warnings.warn("Match value '{:b}' is wider than matched (which has width {}); "
-                              "comparison will never be true"
-                              .format(value, n),
-                              SyntaxWarning, stacklevel=3)
-            return self == value
-        if isinstance(value, str):
-            if len(value) != n:
-                raise SyntaxError("Match value '{}' must have the same width as matched (which is {})"
-                                    .format(value, n))
-            if not all(c in "01-" for c in value):
-                raise SyntaxError("Match value '{}' must contain only 0, 1, or -".format(value))
-            mask = int(value.replace("0", "1").replace("-", "0"), 2)
-            comparand = int(value.replace("-", "0"), 2)
-            return (self & mask) == comparand
-        raise SyntaxError("matches() only accepts strings and integers")
+        operations = []
+        for value in values:
+            if isinstance(value, int):
+                if bits_for(value) > n:
+                    warnings.warn("Match value '{:b}' is wider than matched (which has width {}); "
+                                "comparison will never be true"
+                                .format(value, n),
+                                SyntaxWarning, stacklevel=3)
+                operations.append(self == value)
+            elif isinstance(value, str):
+                if len(value) != n:
+                    raise SyntaxError("Match value '{}' must have the same width as matched (which is {})"
+                                        .format(value, n))
+                if not all(c in "01-" for c in value):
+                    raise SyntaxError("Match value '{}' must contain only 0, 1, or -".format(value))
+                mask = int(value.replace("0", "1").replace("-", "0"), 2)
+                comparand = int(value.replace("-", "0"), 2)
+                operations.append((self & mask) == comparand)
+            else:
+                raise SyntaxError("matches() only accepts strings and integers")
+        if len(operations) == 0:
+            return 0
+        if len(operations) == 1:
+            return operations[0]
+        return functools.reduce(lambda x, y: x|y, operations[1:], operations[0])
 
     @abstractmethod
     def shape(self):

--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -258,7 +258,9 @@ class Value(metaclass=ABCMeta):
         """
         n = len(self)
         if isinstance(value, int):
-            if bits_for(value) > n:
+            value = Const(value)
+        if isinstance(value, Const):
+            if len(value) > n:
                 warnings.warn("Match value '{:b}' is wider than matched (which has width {}); "
                               "comparison will never be true"
                               .format(value, n),

--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -262,16 +262,16 @@ class Value(metaclass=ABCMeta):
                               "comparison will never be true"
                               .format(value, n),
                               SyntaxWarning, stacklevel=3)
-            return Operator("==", [self, value])
+            return self == value
         if isinstance(value, str):
             if len(value) != n:
                 raise SyntaxError("Match value '{}' must have the same width as matched (which is {})"
                                     .format(value, n))
             if not all(c in "01-" for c in value):
                 raise SyntaxError("Match value '{}' must contain only 0, 1, or -".format(value))
-            mask = Const(int(value.replace("0", "1").replace("-", "0"), 2))
-            comparand = Const(int(value.replace("-", "0"), 2))
-            return Operator("==", [Operator("&", [self, mask]), comparand])
+            mask = int(value.replace("0", "1").replace("-", "0"), 2)
+            comparand = int(value.replace("-", "0"), 2)
+            return (self & mask) == comparand
         raise SyntaxError("matches() only accepts strings and integers")
 
     @abstractmethod

--- a/nmigen/test/test_hdl_ast.py
+++ b/nmigen/test/test_hdl_ast.py
@@ -63,6 +63,39 @@ class ValueTestCase(FHDLTestCase):
                 msg="Cannot index value with 'str'"):
             Const(31)["str"]
 
+    def test_matches_int(self):
+        s = Const(0b101) # 3'd5
+        p = Const(0b110) # 3'd6
+        m = s.matches(p)
+        self.assertEqual(repr(m), "(== (const 3'd5) (const 3'd6))")
+
+    def test_matches_str(self):
+        s = Const(0b101) # 3'd5
+        p = "10-"        # mask 3'd6, comparand 3'd4
+        m = s.matches(p)
+        self.assertEqual(repr(m), "(== (& (const 3'd5) (const 3'd6)) (const 3'd4))")
+
+    def test_matches_str_wrong_size(self):
+        with self.assertRaises(TypeError,
+                msg="Match value '1-' must have the same width as matched (which is 3)"):
+            s = Const(0b101)
+            p = "1-"
+            m = s.matches(p)
+
+    def test_matches_str_bad_content(self):
+        with self.assertRaises(TypeError,
+                msg="Match value 'cat' must contain only 0, 1, or -"):
+            s = Const(0b101)
+            p = "cat"
+            m = s.matches(p)
+
+    def test_matches_wrong_type(self):
+        with self.assertRaises(TypeError,
+                msg="matches() only accepts strings and integers"):
+            s = Const(0b101)
+            p = 1.0
+            m = s.matches(p)
+
 
 class ConstTestCase(FHDLTestCase):
     def test_shape(self):

--- a/nmigen/test/test_hdl_ast.py
+++ b/nmigen/test/test_hdl_ast.py
@@ -11,13 +11,13 @@ class ValueTestCase(FHDLTestCase):
         self.assertIsInstance(Value.wrap(True), Const)
         c = Const(0)
         self.assertIs(Value.wrap(c), c)
-        with self.assertRaises(
-                TypeError, msg="Object ''str'' is not an nMigen value"):
+        with self.assertRaises(TypeError,
+                msg="Object ''str'' is not an nMigen value"):
             Value.wrap("str")
 
     def test_bool(self):
-        with self.assertRaises(
-                TypeError, msg="Attempted to convert nMigen value to boolean"):
+        with self.assertRaises(TypeError,
+                msg="Attempted to convert nMigen value to boolean"):
             if Const(0):
                 pass
 
@@ -33,8 +33,8 @@ class ValueTestCase(FHDLTestCase):
         self.assertIsInstance(s2, Slice)
         self.assertEqual(s2.start, 3)
         self.assertEqual(s2.end, 4)
-        with self.assertRaises(
-                IndexError, msg="Cannot index 5 bits into 4-bit value"):
+        with self.assertRaises(IndexError,
+                msg="Cannot index 5 bits into 4-bit value"):
             Const(10)[5]
 
     def test_getitem_slice(self):
@@ -59,20 +59,21 @@ class ValueTestCase(FHDLTestCase):
         self.assertEqual(s3.parts[2].end, 5)
 
     def test_getitem_wrong(self):
-        with self.assertRaises(TypeError, msg="Cannot index value with 'str'"):
+        with self.assertRaises(TypeError,
+                msg="Cannot index value with 'str'"):
             Const(31)["str"]
 
     def test_matches_int(self):
         s = Const(0b101)  # 3'd5
         m = s.matches(6)
-        self.assertEqual(repr(m), "(== (const 3'd5) (const 3'd6))")
+        self.assertEqual(repr(m), "(r| (cat (== (const 3'd5) (const 3'd6))))")
 
     def test_matches_str(self):
         s = Const(0b101)  # 3'd5
         p = "10-"  # mask 3'd6, comparand 3'd4
         m = s.matches(p)
         self.assertEqual(
-            repr(m), "(== (& (const 3'd5) (const 3'd6)) (const 3'd4))")
+            repr(m), "(r| (cat (== (& (const 3'd5) (const 3'd6)) (const 3'd4))))")
 
     def test_matches_str_wrong_size(self):
         with self.assertRaises(
@@ -105,29 +106,28 @@ class ValueTestCase(FHDLTestCase):
         m = s.matches(6, 7)
         self.assertEqual(
             repr(m),
-            "(| (== (const 3'd5) (const 3'd6)) (== (const 3'd5) (const 3'd7)))"
+            "(r| (cat (== (const 3'd5) (const 3'd6)) (== (const 3'd5) (const 3'd7))))"
         )
 
     def test_matches_empty(self):
         s = Const(0b101)  #3'd5
         m = s.matches()
-        self.assertEqual(repr(m), "0")
+        self.assertEqual(repr(m), "(r| (cat ))")
 
 
 class ConstTestCase(FHDLTestCase):
     def test_shape(self):
-        self.assertEqual(Const(0).shape(), (1, False))
-        self.assertEqual(Const(1).shape(), (1, False))
-        self.assertEqual(Const(10).shape(), (4, False))
+        self.assertEqual(Const(0).shape(),   (1, False))
+        self.assertEqual(Const(1).shape(),   (1, False))
+        self.assertEqual(Const(10).shape(),  (4, False))
         self.assertEqual(Const(-10).shape(), (5, True))
 
-        self.assertEqual(Const(1, 4).shape(), (4, False))
-        self.assertEqual(Const(1, (4, True)).shape(), (4, True))
+        self.assertEqual(Const(1, 4).shape(),          (4, False))
+        self.assertEqual(Const(1, (4, True)).shape(),  (4, True))
         self.assertEqual(Const(0, (0, False)).shape(), (0, False))
 
     def test_shape_bad(self):
-        with self.assertRaises(
-                TypeError,
+        with self.assertRaises(TypeError,
                 msg="Width must be a non-negative integer, not '-1'"):
             Const(1, -1)
 
@@ -138,7 +138,7 @@ class ConstTestCase(FHDLTestCase):
         self.assertEqual(Const(10).value, 10)
 
     def test_repr(self):
-        self.assertEqual(repr(Const(10)), "(const 4'd10)")
+        self.assertEqual(repr(Const(10)),  "(const 4'd10)")
         self.assertEqual(repr(Const(-10)), "(const 5'sd-10)")
 
     def test_hash(self):
@@ -286,10 +286,9 @@ class OperatorTestCase(FHDLTestCase):
         self.assertEqual(v.shape(), (1, False))
 
     def test_mux(self):
-        s = Const(0)
+        s  = Const(0)
         v1 = Mux(s, Const(0, (4, False)), Const(0, (6, False)))
-        self.assertEqual(
-            repr(v1), "(m (const 1'd0) (const 4'd0) (const 6'd0))")
+        self.assertEqual(repr(v1), "(m (const 1'd0) (const 4'd0) (const 6'd0))")
         self.assertEqual(v1.shape(), (6, False))
         v2 = Mux(s, Const(0, (4, True)), Const(0, (6, True)))
         self.assertEqual(v2.shape(), (6, True))
@@ -328,30 +327,30 @@ class SliceTestCase(FHDLTestCase):
         self.assertEqual(s2.shape(), (2, False))
 
     def test_start_end_negative(self):
-        c = Const(0, 8)
+        c  = Const(0, 8)
         s1 = Slice(c, 0, -1)
         self.assertEqual((s1.start, s1.end), (0, 7))
         s1 = Slice(c, -4, -1)
         self.assertEqual((s1.start, s1.end), (4, 7))
 
     def test_start_end_wrong(self):
-        with self.assertRaises(
-                TypeError, msg="Slice start must be an integer, not ''x''"):
+        with self.assertRaises(TypeError,
+                msg="Slice start must be an integer, not ''x''"):
             Slice(0, "x", 1)
-        with self.assertRaises(
-                TypeError, msg="Slice end must be an integer, not ''x''"):
+        with self.assertRaises(TypeError,
+                msg="Slice end must be an integer, not ''x''"):
             Slice(0, 1, "x")
 
     def test_start_end_out_of_range(self):
         c = Const(0, 8)
-        with self.assertRaises(
-                IndexError, msg="Cannot start slice 10 bits into 8-bit value"):
+        with self.assertRaises(IndexError,
+                msg="Cannot start slice 10 bits into 8-bit value"):
             Slice(c, 10, 12)
-        with self.assertRaises(
-                IndexError, msg="Cannot end slice 12 bits into 8-bit value"):
+        with self.assertRaises(IndexError,
+                msg="Cannot end slice 12 bits into 8-bit value"):
             Slice(c, 0, 12)
-        with self.assertRaises(
-                IndexError, msg="Slice start 4 must be less than slice end 2"):
+        with self.assertRaises(IndexError,
+                msg="Slice start 4 must be less than slice end 2"):
             Slice(c, 4, 2)
 
     def test_repr(self):
@@ -443,43 +442,34 @@ class ReplTestCase(FHDLTestCase):
 
 class ArrayTestCase(FHDLTestCase):
     def test_acts_like_array(self):
-        a = Array([1, 2, 3])
-        self.assertSequenceEqual(a, [1, 2, 3])
+        a = Array([1,2,3])
+        self.assertSequenceEqual(a, [1,2,3])
         self.assertEqual(a[1], 2)
         a[1] = 4
-        self.assertSequenceEqual(a, [1, 4, 3])
+        self.assertSequenceEqual(a, [1,4,3])
         del a[1]
-        self.assertSequenceEqual(a, [1, 3])
+        self.assertSequenceEqual(a, [1,3])
         a.insert(1, 2)
-        self.assertSequenceEqual(a, [1, 2, 3])
+        self.assertSequenceEqual(a, [1,2,3])
 
     def test_becomes_immutable(self):
-        a = Array([1, 2, 3])
+        a = Array([1,2,3])
         s1 = Signal.range(len(a))
         s2 = Signal.range(len(a))
         v1 = a[s1]
         v2 = a[s2]
-        with self.assertRaisesRegex(
-                ValueError,
-                regex=
-                r"^Array can no longer be mutated after it was indexed with a value at "
-        ):
+        with self.assertRaisesRegex(ValueError,
+                regex=r"^Array can no longer be mutated after it was indexed with a value at "):
             a[1] = 2
-        with self.assertRaisesRegex(
-                ValueError,
-                regex=
-                r"^Array can no longer be mutated after it was indexed with a value at "
-        ):
+        with self.assertRaisesRegex(ValueError,
+                regex=r"^Array can no longer be mutated after it was indexed with a value at "):
             del a[1]
-        with self.assertRaisesRegex(
-                ValueError,
-                regex=
-                r"^Array can no longer be mutated after it was indexed with a value at "
-        ):
+        with self.assertRaisesRegex(ValueError,
+                regex=r"^Array can no longer be mutated after it was indexed with a value at "):
             a.insert(1, 2)
 
     def test_repr(self):
-        a = Array([1, 2, 3])
+        a = Array([1,2,3])
         self.assertEqual(repr(a), "(array mutable [1, 2, 3])")
         s = Signal.range(len(a))
         v = a[s]
@@ -536,8 +526,7 @@ class SignalTestCase(FHDLTestCase):
         self.assertEqual(s11.shape(), (1, False))
         # deprecated
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                action="ignore", category=DeprecationWarning)
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
             d6 = Signal(max=16)
             self.assertEqual(d6.shape(), (4, False))
             d7 = Signal(min=4, max=16)
@@ -550,31 +539,21 @@ class SignalTestCase(FHDLTestCase):
             self.assertEqual(d10.shape(), (0, False))
 
     def test_shape_bad(self):
-        with self.assertRaises(
-                TypeError,
+        with self.assertRaises(TypeError,
                 msg="Width must be a non-negative integer, not '-10'"):
             Signal(-10)
 
     def test_min_max_deprecated(self):
-        with self.assertWarns(
-                DeprecationWarning,
-                msg=
-                "instead of `Signal(min=0, max=10)`, use `Signal.range(0, 10)`"
-        ):
+        with self.assertWarns(DeprecationWarning,
+                msg="instead of `Signal(min=0, max=10)`, use `Signal.range(0, 10)`"):
             Signal(max=10)
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                action="ignore", category=DeprecationWarning)
-            with self.assertRaises(
-                    ValueError,
-                    msg=
-                    "Lower bound 10 should be less or equal to higher bound 4"
-            ):
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            with self.assertRaises(ValueError,
+                    msg="Lower bound 10 should be less or equal to higher bound 4"):
                 Signal(min=10, max=4)
-            with self.assertRaises(
-                    ValueError,
-                    msg="Only one of bits/signedness or bounds may be specified"
-            ):
+            with self.assertRaises(ValueError,
+                    msg="Only one of bits/signedness or bounds may be specified"):
                 Signal(2, min=10)
 
     def test_name(self):
@@ -584,8 +563,8 @@ class SignalTestCase(FHDLTestCase):
         self.assertEqual(s2.name, "sig")
 
     def test_name_bad(self):
-        with self.assertRaises(
-                TypeError, msg="Name must be a string, not 'True'"):
+        with self.assertRaises(TypeError,
+                msg="Name must be a string, not 'True'"):
             # A common typo: forgetting to put parens around width and signedness
             Signal(1, True)
 
@@ -595,23 +574,14 @@ class SignalTestCase(FHDLTestCase):
         self.assertEqual(s1.reset_less, True)
 
     def test_reset_narrow(self):
-        with self.assertWarns(
-                SyntaxWarning,
-                msg=
-                "Reset value 8 requires 4 bits to represent, but the signal only has 3 bits"
-        ):
+        with self.assertWarns(SyntaxWarning,
+                msg="Reset value 8 requires 4 bits to represent, but the signal only has 3 bits"):
             Signal(3, reset=8)
-        with self.assertWarns(
-                SyntaxWarning,
-                msg=
-                "Reset value 4 requires 4 bits to represent, but the signal only has 3 bits"
-        ):
+        with self.assertWarns(SyntaxWarning,
+                msg="Reset value 4 requires 4 bits to represent, but the signal only has 3 bits"):
             Signal((3, True), reset=4)
-        with self.assertWarns(
-                SyntaxWarning,
-                msg=
-                "Reset value -5 requires 4 bits to represent, but the signal only has 3 bits"
-        ):
+        with self.assertWarns(SyntaxWarning,
+                msg="Reset value -5 requires 4 bits to represent, but the signal only has 3 bits"):
             Signal((3, True), reset=-5)
 
     def test_attrs(self):
@@ -645,9 +615,8 @@ class SignalTestCase(FHDLTestCase):
 
     def test_decoder(self):
         class Color(Enum):
-            RED = 1
+            RED  = 1
             BLUE = 2
-
         s = Signal(decoder=Color)
         self.assertEqual(s.decoder(1), "RED/1")
         self.assertEqual(s.decoder(3), "3")
@@ -660,8 +629,8 @@ class ClockSignalTestCase(FHDLTestCase):
         s2 = ClockSignal("pix")
         self.assertEqual(s2.domain, "pix")
 
-        with self.assertRaises(
-                TypeError, msg="Clock domain name must be a string, not '1'"):
+        with self.assertRaises(TypeError,
+                msg="Clock domain name must be a string, not '1'"):
             ClockSignal(1)
 
     def test_shape(self):
@@ -672,8 +641,8 @@ class ClockSignalTestCase(FHDLTestCase):
         self.assertEqual(repr(s1), "(clk sync)")
 
     def test_wrong_name_comb(self):
-        with self.assertRaises(
-                ValueError, msg="Domain 'comb' does not have a clock"):
+        with self.assertRaises(ValueError,
+                msg="Domain 'comb' does not have a clock"):
             ClockSignal("comb")
 
 
@@ -684,8 +653,8 @@ class ResetSignalTestCase(FHDLTestCase):
         s2 = ResetSignal("pix")
         self.assertEqual(s2.domain, "pix")
 
-        with self.assertRaises(
-                TypeError, msg="Clock domain name must be a string, not '1'"):
+        with self.assertRaises(TypeError,
+                msg="Clock domain name must be a string, not '1'"):
             ResetSignal(1)
 
     def test_shape(self):
@@ -696,8 +665,8 @@ class ResetSignalTestCase(FHDLTestCase):
         self.assertEqual(repr(s1), "(rst sync)")
 
     def test_wrong_name_comb(self):
-        with self.assertRaises(
-                ValueError, msg="Domain 'comb' does not have a reset"):
+        with self.assertRaises(ValueError,
+                msg="Domain 'comb' does not have a reset"):
             ResetSignal("comb")
 
 
@@ -705,7 +674,7 @@ class MockUserValue(UserValue):
     def __init__(self, lowered):
         super().__init__()
         self.lower_count = 0
-        self.lowered = lowered
+        self.lowered     = lowered
 
     def lower(self):
         self.lower_count += 1
@@ -733,19 +702,19 @@ class SampleTestCase(FHDLTestCase):
         s3 = Sample(ResetSignal(), 1, "sync")
 
     def test_wrong_value_operator(self):
-        with self.assertRaises(
-                TypeError, "Sampled value must be a signal or a constant, not "
+        with self.assertRaises(TypeError,
+                "Sampled value must be a signal or a constant, not "
                 "(+ (sig $signal) (const 1'd1))"):
             Sample(Signal() + 1, 1, "sync")
 
     def test_wrong_clocks_neg(self):
         with self.assertRaises(ValueError,
-                               "Cannot sample a value 1 cycles in the future"):
+                "Cannot sample a value 1 cycles in the future"):
             Sample(Signal(), -1, "sync")
 
     def test_wrong_domain(self):
         with self.assertRaises(TypeError,
-                               "Domain name must be a string or None, not 0"):
+                "Domain name must be a string or None, not 0"):
             Sample(Signal(), 1, 0)
 
 

--- a/nmigen/test/test_hdl_ast.py
+++ b/nmigen/test/test_hdl_ast.py
@@ -63,12 +63,6 @@ class ValueTestCase(FHDLTestCase):
                 msg="Cannot index value with 'str'"):
             Const(31)["str"]
 
-    def test_matches_const(self):
-        s = Const(0b101) # 3'd5
-        p = Const(0b110) # 3'd6
-        m = s.matches(p)
-        self.assertEqual(repr(m), "(== (const 3'd5) (const 3'd6))")
-
     def test_matches_int(self):
         s = Const(0b101) # 3'd5
         m = s.matches(6)

--- a/nmigen/test/test_hdl_ast.py
+++ b/nmigen/test/test_hdl_ast.py
@@ -11,13 +11,13 @@ class ValueTestCase(FHDLTestCase):
         self.assertIsInstance(Value.wrap(True), Const)
         c = Const(0)
         self.assertIs(Value.wrap(c), c)
-        with self.assertRaises(
-                TypeError, msg="Object ''str'' is not an nMigen value"):
+        with self.assertRaises(TypeError,
+                msg="Object ''str'' is not an nMigen value"):
             Value.wrap("str")
 
     def test_bool(self):
-        with self.assertRaises(
-                TypeError, msg="Attempted to convert nMigen value to boolean"):
+        with self.assertRaises(TypeError,
+                msg="Attempted to convert nMigen value to boolean"):
             if Const(0):
                 pass
 
@@ -33,8 +33,8 @@ class ValueTestCase(FHDLTestCase):
         self.assertIsInstance(s2, Slice)
         self.assertEqual(s2.start, 3)
         self.assertEqual(s2.end, 4)
-        with self.assertRaises(
-                IndexError, msg="Cannot index 5 bits into 4-bit value"):
+        with self.assertRaises(IndexError,
+                msg="Cannot index 5 bits into 4-bit value"):
             Const(10)[5]
 
     def test_getitem_slice(self):
@@ -59,75 +59,24 @@ class ValueTestCase(FHDLTestCase):
         self.assertEqual(s3.parts[2].end, 5)
 
     def test_getitem_wrong(self):
-        with self.assertRaises(TypeError, msg="Cannot index value with 'str'"):
+        with self.assertRaises(TypeError,
+                msg="Cannot index value with 'str'"):
             Const(31)["str"]
-
-    def test_matches_int(self):
-        s = Const(0b101)  # 3'd5
-        m = s.matches(6)
-        self.assertEqual(repr(m), "(r| (cat (== (const 3'd5) (const 3'd6))))")
-
-    def test_matches_str(self):
-        s = Const(0b101)  # 3'd5
-        p = "10-"  # mask 3'd6, comparand 3'd4
-        m = s.matches(p)
-        self.assertEqual(
-            repr(m), "(r| (cat (== (& (const 3'd5) (const 3'd6)) (const 3'd4))))")
-
-    def test_matches_str_wrong_size(self):
-        with self.assertRaises(
-                SyntaxError,
-                msg=
-                "Match value '1-' must have the same width as matched (which is 3)"
-        ):
-            s = Const(0b101)
-            p = "1-"
-            m = s.matches(p)
-
-    def test_matches_str_bad_content(self):
-        with self.assertRaises(
-                SyntaxError,
-                msg="Match value 'cat' must contain only 0, 1, or -"):
-            s = Const(0b101)
-            p = "cat"
-            m = s.matches(p)
-
-    def test_matches_wrong_type(self):
-        with self.assertRaises(
-                SyntaxError,
-                msg="matches() only accepts strings and integers"):
-            s = Const(0b101)
-            p = 1.0
-            m = s.matches(p)
-
-    def test_matches_multiple(self):
-        s = Const(0b101)  #3'd5
-        m = s.matches(6, 7)
-        self.assertEqual(
-            repr(m),
-            "(r| (cat (== (const 3'd5) (const 3'd6)) (== (const 3'd5) (const 3'd7))))"
-        )
-
-    def test_matches_empty(self):
-        s = Const(0b101)  #3'd5
-        m = s.matches()
-        self.assertEqual(repr(m), "(r| (cat ))")
 
 
 class ConstTestCase(FHDLTestCase):
     def test_shape(self):
-        self.assertEqual(Const(0).shape(), (1, False))
-        self.assertEqual(Const(1).shape(), (1, False))
-        self.assertEqual(Const(10).shape(), (4, False))
+        self.assertEqual(Const(0).shape(),   (1, False))
+        self.assertEqual(Const(1).shape(),   (1, False))
+        self.assertEqual(Const(10).shape(),  (4, False))
         self.assertEqual(Const(-10).shape(), (5, True))
 
-        self.assertEqual(Const(1, 4).shape(), (4, False))
-        self.assertEqual(Const(1, (4, True)).shape(), (4, True))
+        self.assertEqual(Const(1, 4).shape(),          (4, False))
+        self.assertEqual(Const(1, (4, True)).shape(),  (4, True))
         self.assertEqual(Const(0, (0, False)).shape(), (0, False))
 
     def test_shape_bad(self):
-        with self.assertRaises(
-                TypeError,
+        with self.assertRaises(TypeError,
                 msg="Width must be a non-negative integer, not '-1'"):
             Const(1, -1)
 
@@ -138,7 +87,7 @@ class ConstTestCase(FHDLTestCase):
         self.assertEqual(Const(10).value, 10)
 
     def test_repr(self):
-        self.assertEqual(repr(Const(10)), "(const 4'd10)")
+        self.assertEqual(repr(Const(10)),  "(const 4'd10)")
         self.assertEqual(repr(Const(-10)), "(const 5'sd-10)")
 
     def test_hash(self):
@@ -286,10 +235,9 @@ class OperatorTestCase(FHDLTestCase):
         self.assertEqual(v.shape(), (1, False))
 
     def test_mux(self):
-        s = Const(0)
+        s  = Const(0)
         v1 = Mux(s, Const(0, (4, False)), Const(0, (6, False)))
-        self.assertEqual(
-            repr(v1), "(m (const 1'd0) (const 4'd0) (const 6'd0))")
+        self.assertEqual(repr(v1), "(m (const 1'd0) (const 4'd0) (const 6'd0))")
         self.assertEqual(v1.shape(), (6, False))
         v2 = Mux(s, Const(0, (4, True)), Const(0, (6, True)))
         self.assertEqual(v2.shape(), (6, True))
@@ -328,30 +276,30 @@ class SliceTestCase(FHDLTestCase):
         self.assertEqual(s2.shape(), (2, False))
 
     def test_start_end_negative(self):
-        c = Const(0, 8)
+        c  = Const(0, 8)
         s1 = Slice(c, 0, -1)
         self.assertEqual((s1.start, s1.end), (0, 7))
         s1 = Slice(c, -4, -1)
         self.assertEqual((s1.start, s1.end), (4, 7))
 
     def test_start_end_wrong(self):
-        with self.assertRaises(
-                TypeError, msg="Slice start must be an integer, not ''x''"):
+        with self.assertRaises(TypeError,
+                msg="Slice start must be an integer, not ''x''"):
             Slice(0, "x", 1)
-        with self.assertRaises(
-                TypeError, msg="Slice end must be an integer, not ''x''"):
+        with self.assertRaises(TypeError,
+                msg="Slice end must be an integer, not ''x''"):
             Slice(0, 1, "x")
 
     def test_start_end_out_of_range(self):
         c = Const(0, 8)
-        with self.assertRaises(
-                IndexError, msg="Cannot start slice 10 bits into 8-bit value"):
+        with self.assertRaises(IndexError,
+                msg="Cannot start slice 10 bits into 8-bit value"):
             Slice(c, 10, 12)
-        with self.assertRaises(
-                IndexError, msg="Cannot end slice 12 bits into 8-bit value"):
+        with self.assertRaises(IndexError,
+                msg="Cannot end slice 12 bits into 8-bit value"):
             Slice(c, 0, 12)
-        with self.assertRaises(
-                IndexError, msg="Slice start 4 must be less than slice end 2"):
+        with self.assertRaises(IndexError,
+                msg="Slice start 4 must be less than slice end 2"):
             Slice(c, 4, 2)
 
     def test_repr(self):
@@ -443,43 +391,34 @@ class ReplTestCase(FHDLTestCase):
 
 class ArrayTestCase(FHDLTestCase):
     def test_acts_like_array(self):
-        a = Array([1, 2, 3])
-        self.assertSequenceEqual(a, [1, 2, 3])
+        a = Array([1,2,3])
+        self.assertSequenceEqual(a, [1,2,3])
         self.assertEqual(a[1], 2)
         a[1] = 4
-        self.assertSequenceEqual(a, [1, 4, 3])
+        self.assertSequenceEqual(a, [1,4,3])
         del a[1]
-        self.assertSequenceEqual(a, [1, 3])
+        self.assertSequenceEqual(a, [1,3])
         a.insert(1, 2)
-        self.assertSequenceEqual(a, [1, 2, 3])
+        self.assertSequenceEqual(a, [1,2,3])
 
     def test_becomes_immutable(self):
-        a = Array([1, 2, 3])
+        a = Array([1,2,3])
         s1 = Signal.range(len(a))
         s2 = Signal.range(len(a))
         v1 = a[s1]
         v2 = a[s2]
-        with self.assertRaisesRegex(
-                ValueError,
-                regex=
-                r"^Array can no longer be mutated after it was indexed with a value at "
-        ):
+        with self.assertRaisesRegex(ValueError,
+                regex=r"^Array can no longer be mutated after it was indexed with a value at "):
             a[1] = 2
-        with self.assertRaisesRegex(
-                ValueError,
-                regex=
-                r"^Array can no longer be mutated after it was indexed with a value at "
-        ):
+        with self.assertRaisesRegex(ValueError,
+                regex=r"^Array can no longer be mutated after it was indexed with a value at "):
             del a[1]
-        with self.assertRaisesRegex(
-                ValueError,
-                regex=
-                r"^Array can no longer be mutated after it was indexed with a value at "
-        ):
+        with self.assertRaisesRegex(ValueError,
+                regex=r"^Array can no longer be mutated after it was indexed with a value at "):
             a.insert(1, 2)
 
     def test_repr(self):
-        a = Array([1, 2, 3])
+        a = Array([1,2,3])
         self.assertEqual(repr(a), "(array mutable [1, 2, 3])")
         s = Signal.range(len(a))
         v = a[s]
@@ -536,8 +475,7 @@ class SignalTestCase(FHDLTestCase):
         self.assertEqual(s11.shape(), (1, False))
         # deprecated
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                action="ignore", category=DeprecationWarning)
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
             d6 = Signal(max=16)
             self.assertEqual(d6.shape(), (4, False))
             d7 = Signal(min=4, max=16)
@@ -550,31 +488,21 @@ class SignalTestCase(FHDLTestCase):
             self.assertEqual(d10.shape(), (0, False))
 
     def test_shape_bad(self):
-        with self.assertRaises(
-                TypeError,
+        with self.assertRaises(TypeError,
                 msg="Width must be a non-negative integer, not '-10'"):
             Signal(-10)
 
     def test_min_max_deprecated(self):
-        with self.assertWarns(
-                DeprecationWarning,
-                msg=
-                "instead of `Signal(min=0, max=10)`, use `Signal.range(0, 10)`"
-        ):
+        with self.assertWarns(DeprecationWarning,
+                msg="instead of `Signal(min=0, max=10)`, use `Signal.range(0, 10)`"):
             Signal(max=10)
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                action="ignore", category=DeprecationWarning)
-            with self.assertRaises(
-                    ValueError,
-                    msg=
-                    "Lower bound 10 should be less or equal to higher bound 4"
-            ):
+            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            with self.assertRaises(ValueError,
+                    msg="Lower bound 10 should be less or equal to higher bound 4"):
                 Signal(min=10, max=4)
-            with self.assertRaises(
-                    ValueError,
-                    msg="Only one of bits/signedness or bounds may be specified"
-            ):
+            with self.assertRaises(ValueError,
+                    msg="Only one of bits/signedness or bounds may be specified"):
                 Signal(2, min=10)
 
     def test_name(self):
@@ -584,8 +512,8 @@ class SignalTestCase(FHDLTestCase):
         self.assertEqual(s2.name, "sig")
 
     def test_name_bad(self):
-        with self.assertRaises(
-                TypeError, msg="Name must be a string, not 'True'"):
+        with self.assertRaises(TypeError,
+                msg="Name must be a string, not 'True'"):
             # A common typo: forgetting to put parens around width and signedness
             Signal(1, True)
 
@@ -595,23 +523,14 @@ class SignalTestCase(FHDLTestCase):
         self.assertEqual(s1.reset_less, True)
 
     def test_reset_narrow(self):
-        with self.assertWarns(
-                SyntaxWarning,
-                msg=
-                "Reset value 8 requires 4 bits to represent, but the signal only has 3 bits"
-        ):
+        with self.assertWarns(SyntaxWarning,
+                msg="Reset value 8 requires 4 bits to represent, but the signal only has 3 bits"):
             Signal(3, reset=8)
-        with self.assertWarns(
-                SyntaxWarning,
-                msg=
-                "Reset value 4 requires 4 bits to represent, but the signal only has 3 bits"
-        ):
+        with self.assertWarns(SyntaxWarning,
+                msg="Reset value 4 requires 4 bits to represent, but the signal only has 3 bits"):
             Signal((3, True), reset=4)
-        with self.assertWarns(
-                SyntaxWarning,
-                msg=
-                "Reset value -5 requires 4 bits to represent, but the signal only has 3 bits"
-        ):
+        with self.assertWarns(SyntaxWarning,
+                msg="Reset value -5 requires 4 bits to represent, but the signal only has 3 bits"):
             Signal((3, True), reset=-5)
 
     def test_attrs(self):
@@ -645,9 +564,8 @@ class SignalTestCase(FHDLTestCase):
 
     def test_decoder(self):
         class Color(Enum):
-            RED = 1
+            RED  = 1
             BLUE = 2
-
         s = Signal(decoder=Color)
         self.assertEqual(s.decoder(1), "RED/1")
         self.assertEqual(s.decoder(3), "3")
@@ -660,8 +578,8 @@ class ClockSignalTestCase(FHDLTestCase):
         s2 = ClockSignal("pix")
         self.assertEqual(s2.domain, "pix")
 
-        with self.assertRaises(
-                TypeError, msg="Clock domain name must be a string, not '1'"):
+        with self.assertRaises(TypeError,
+                msg="Clock domain name must be a string, not '1'"):
             ClockSignal(1)
 
     def test_shape(self):
@@ -672,8 +590,8 @@ class ClockSignalTestCase(FHDLTestCase):
         self.assertEqual(repr(s1), "(clk sync)")
 
     def test_wrong_name_comb(self):
-        with self.assertRaises(
-                ValueError, msg="Domain 'comb' does not have a clock"):
+        with self.assertRaises(ValueError,
+                msg="Domain 'comb' does not have a clock"):
             ClockSignal("comb")
 
 
@@ -684,8 +602,8 @@ class ResetSignalTestCase(FHDLTestCase):
         s2 = ResetSignal("pix")
         self.assertEqual(s2.domain, "pix")
 
-        with self.assertRaises(
-                TypeError, msg="Clock domain name must be a string, not '1'"):
+        with self.assertRaises(TypeError,
+                msg="Clock domain name must be a string, not '1'"):
             ResetSignal(1)
 
     def test_shape(self):
@@ -696,8 +614,8 @@ class ResetSignalTestCase(FHDLTestCase):
         self.assertEqual(repr(s1), "(rst sync)")
 
     def test_wrong_name_comb(self):
-        with self.assertRaises(
-                ValueError, msg="Domain 'comb' does not have a reset"):
+        with self.assertRaises(ValueError,
+                msg="Domain 'comb' does not have a reset"):
             ResetSignal("comb")
 
 
@@ -705,7 +623,7 @@ class MockUserValue(UserValue):
     def __init__(self, lowered):
         super().__init__()
         self.lower_count = 0
-        self.lowered = lowered
+        self.lowered     = lowered
 
     def lower(self):
         self.lower_count += 1
@@ -733,19 +651,19 @@ class SampleTestCase(FHDLTestCase):
         s3 = Sample(ResetSignal(), 1, "sync")
 
     def test_wrong_value_operator(self):
-        with self.assertRaises(
-                TypeError, "Sampled value must be a signal or a constant, not "
+        with self.assertRaises(TypeError,
+                "Sampled value must be a signal or a constant, not "
                 "(+ (sig $signal) (const 1'd1))"):
             Sample(Signal() + 1, 1, "sync")
 
     def test_wrong_clocks_neg(self):
         with self.assertRaises(ValueError,
-                               "Cannot sample a value 1 cycles in the future"):
+                "Cannot sample a value 1 cycles in the future"):
             Sample(Signal(), -1, "sync")
 
     def test_wrong_domain(self):
         with self.assertRaises(TypeError,
-                               "Domain name must be a string or None, not 0"):
+                "Domain name must be a string or None, not 0"):
             Sample(Signal(), 1, 0)
 
 

--- a/nmigen/test/test_hdl_ast.py
+++ b/nmigen/test/test_hdl_ast.py
@@ -63,10 +63,15 @@ class ValueTestCase(FHDLTestCase):
                 msg="Cannot index value with 'str'"):
             Const(31)["str"]
 
-    def test_matches_int(self):
+    def test_matches_const(self):
         s = Const(0b101) # 3'd5
         p = Const(0b110) # 3'd6
         m = s.matches(p)
+        self.assertEqual(repr(m), "(== (const 3'd5) (const 3'd6))")
+
+    def test_matches_int(self):
+        s = Const(0b101) # 3'd5
+        m = s.matches(6)
         self.assertEqual(repr(m), "(== (const 3'd5) (const 3'd6))")
 
     def test_matches_str(self):
@@ -76,21 +81,21 @@ class ValueTestCase(FHDLTestCase):
         self.assertEqual(repr(m), "(== (& (const 3'd5) (const 3'd6)) (const 3'd4))")
 
     def test_matches_str_wrong_size(self):
-        with self.assertRaises(TypeError,
+        with self.assertRaises(SyntaxError,
                 msg="Match value '1-' must have the same width as matched (which is 3)"):
             s = Const(0b101)
             p = "1-"
             m = s.matches(p)
 
     def test_matches_str_bad_content(self):
-        with self.assertRaises(TypeError,
+        with self.assertRaises(SyntaxError,
                 msg="Match value 'cat' must contain only 0, 1, or -"):
             s = Const(0b101)
             p = "cat"
             m = s.matches(p)
 
     def test_matches_wrong_type(self):
-        with self.assertRaises(TypeError,
+        with self.assertRaises(SyntaxError,
                 msg="matches() only accepts strings and integers"):
             s = Const(0b101)
             p = 1.0

--- a/nmigen/test/test_hdl_ast.py
+++ b/nmigen/test/test_hdl_ast.py
@@ -11,13 +11,13 @@ class ValueTestCase(FHDLTestCase):
         self.assertIsInstance(Value.wrap(True), Const)
         c = Const(0)
         self.assertIs(Value.wrap(c), c)
-        with self.assertRaises(TypeError,
-                msg="Object ''str'' is not an nMigen value"):
+        with self.assertRaises(
+                TypeError, msg="Object ''str'' is not an nMigen value"):
             Value.wrap("str")
 
     def test_bool(self):
-        with self.assertRaises(TypeError,
-                msg="Attempted to convert nMigen value to boolean"):
+        with self.assertRaises(
+                TypeError, msg="Attempted to convert nMigen value to boolean"):
             if Const(0):
                 pass
 
@@ -33,8 +33,8 @@ class ValueTestCase(FHDLTestCase):
         self.assertIsInstance(s2, Slice)
         self.assertEqual(s2.start, 3)
         self.assertEqual(s2.end, 4)
-        with self.assertRaises(IndexError,
-                msg="Cannot index 5 bits into 4-bit value"):
+        with self.assertRaises(
+                IndexError, msg="Cannot index 5 bits into 4-bit value"):
             Const(10)[5]
 
     def test_getitem_slice(self):
@@ -59,56 +59,75 @@ class ValueTestCase(FHDLTestCase):
         self.assertEqual(s3.parts[2].end, 5)
 
     def test_getitem_wrong(self):
-        with self.assertRaises(TypeError,
-                msg="Cannot index value with 'str'"):
+        with self.assertRaises(TypeError, msg="Cannot index value with 'str'"):
             Const(31)["str"]
 
     def test_matches_int(self):
-        s = Const(0b101) # 3'd5
+        s = Const(0b101)  # 3'd5
         m = s.matches(6)
         self.assertEqual(repr(m), "(== (const 3'd5) (const 3'd6))")
 
     def test_matches_str(self):
-        s = Const(0b101) # 3'd5
-        p = "10-"        # mask 3'd6, comparand 3'd4
+        s = Const(0b101)  # 3'd5
+        p = "10-"  # mask 3'd6, comparand 3'd4
         m = s.matches(p)
-        self.assertEqual(repr(m), "(== (& (const 3'd5) (const 3'd6)) (const 3'd4))")
+        self.assertEqual(
+            repr(m), "(== (& (const 3'd5) (const 3'd6)) (const 3'd4))")
 
     def test_matches_str_wrong_size(self):
-        with self.assertRaises(SyntaxError,
-                msg="Match value '1-' must have the same width as matched (which is 3)"):
+        with self.assertRaises(
+                SyntaxError,
+                msg=
+                "Match value '1-' must have the same width as matched (which is 3)"
+        ):
             s = Const(0b101)
             p = "1-"
             m = s.matches(p)
 
     def test_matches_str_bad_content(self):
-        with self.assertRaises(SyntaxError,
+        with self.assertRaises(
+                SyntaxError,
                 msg="Match value 'cat' must contain only 0, 1, or -"):
             s = Const(0b101)
             p = "cat"
             m = s.matches(p)
 
     def test_matches_wrong_type(self):
-        with self.assertRaises(SyntaxError,
+        with self.assertRaises(
+                SyntaxError,
                 msg="matches() only accepts strings and integers"):
             s = Const(0b101)
             p = 1.0
             m = s.matches(p)
 
+    def test_matches_multiple(self):
+        s = Const(0b101)  #3'd5
+        m = s.matches(6, 7)
+        self.assertEqual(
+            repr(m),
+            "(| (== (const 3'd5) (const 3'd6)) (== (const 3'd5) (const 3'd7)))"
+        )
+
+    def test_matches_empty(self):
+        s = Const(0b101)  #3'd5
+        m = s.matches()
+        self.assertEqual(repr(m), "0")
+
 
 class ConstTestCase(FHDLTestCase):
     def test_shape(self):
-        self.assertEqual(Const(0).shape(),   (1, False))
-        self.assertEqual(Const(1).shape(),   (1, False))
-        self.assertEqual(Const(10).shape(),  (4, False))
+        self.assertEqual(Const(0).shape(), (1, False))
+        self.assertEqual(Const(1).shape(), (1, False))
+        self.assertEqual(Const(10).shape(), (4, False))
         self.assertEqual(Const(-10).shape(), (5, True))
 
-        self.assertEqual(Const(1, 4).shape(),          (4, False))
-        self.assertEqual(Const(1, (4, True)).shape(),  (4, True))
+        self.assertEqual(Const(1, 4).shape(), (4, False))
+        self.assertEqual(Const(1, (4, True)).shape(), (4, True))
         self.assertEqual(Const(0, (0, False)).shape(), (0, False))
 
     def test_shape_bad(self):
-        with self.assertRaises(TypeError,
+        with self.assertRaises(
+                TypeError,
                 msg="Width must be a non-negative integer, not '-1'"):
             Const(1, -1)
 
@@ -119,7 +138,7 @@ class ConstTestCase(FHDLTestCase):
         self.assertEqual(Const(10).value, 10)
 
     def test_repr(self):
-        self.assertEqual(repr(Const(10)),  "(const 4'd10)")
+        self.assertEqual(repr(Const(10)), "(const 4'd10)")
         self.assertEqual(repr(Const(-10)), "(const 5'sd-10)")
 
     def test_hash(self):
@@ -267,9 +286,10 @@ class OperatorTestCase(FHDLTestCase):
         self.assertEqual(v.shape(), (1, False))
 
     def test_mux(self):
-        s  = Const(0)
+        s = Const(0)
         v1 = Mux(s, Const(0, (4, False)), Const(0, (6, False)))
-        self.assertEqual(repr(v1), "(m (const 1'd0) (const 4'd0) (const 6'd0))")
+        self.assertEqual(
+            repr(v1), "(m (const 1'd0) (const 4'd0) (const 6'd0))")
         self.assertEqual(v1.shape(), (6, False))
         v2 = Mux(s, Const(0, (4, True)), Const(0, (6, True)))
         self.assertEqual(v2.shape(), (6, True))
@@ -308,30 +328,30 @@ class SliceTestCase(FHDLTestCase):
         self.assertEqual(s2.shape(), (2, False))
 
     def test_start_end_negative(self):
-        c  = Const(0, 8)
+        c = Const(0, 8)
         s1 = Slice(c, 0, -1)
         self.assertEqual((s1.start, s1.end), (0, 7))
         s1 = Slice(c, -4, -1)
         self.assertEqual((s1.start, s1.end), (4, 7))
 
     def test_start_end_wrong(self):
-        with self.assertRaises(TypeError,
-                msg="Slice start must be an integer, not ''x''"):
+        with self.assertRaises(
+                TypeError, msg="Slice start must be an integer, not ''x''"):
             Slice(0, "x", 1)
-        with self.assertRaises(TypeError,
-                msg="Slice end must be an integer, not ''x''"):
+        with self.assertRaises(
+                TypeError, msg="Slice end must be an integer, not ''x''"):
             Slice(0, 1, "x")
 
     def test_start_end_out_of_range(self):
         c = Const(0, 8)
-        with self.assertRaises(IndexError,
-                msg="Cannot start slice 10 bits into 8-bit value"):
+        with self.assertRaises(
+                IndexError, msg="Cannot start slice 10 bits into 8-bit value"):
             Slice(c, 10, 12)
-        with self.assertRaises(IndexError,
-                msg="Cannot end slice 12 bits into 8-bit value"):
+        with self.assertRaises(
+                IndexError, msg="Cannot end slice 12 bits into 8-bit value"):
             Slice(c, 0, 12)
-        with self.assertRaises(IndexError,
-                msg="Slice start 4 must be less than slice end 2"):
+        with self.assertRaises(
+                IndexError, msg="Slice start 4 must be less than slice end 2"):
             Slice(c, 4, 2)
 
     def test_repr(self):
@@ -423,34 +443,43 @@ class ReplTestCase(FHDLTestCase):
 
 class ArrayTestCase(FHDLTestCase):
     def test_acts_like_array(self):
-        a = Array([1,2,3])
-        self.assertSequenceEqual(a, [1,2,3])
+        a = Array([1, 2, 3])
+        self.assertSequenceEqual(a, [1, 2, 3])
         self.assertEqual(a[1], 2)
         a[1] = 4
-        self.assertSequenceEqual(a, [1,4,3])
+        self.assertSequenceEqual(a, [1, 4, 3])
         del a[1]
-        self.assertSequenceEqual(a, [1,3])
+        self.assertSequenceEqual(a, [1, 3])
         a.insert(1, 2)
-        self.assertSequenceEqual(a, [1,2,3])
+        self.assertSequenceEqual(a, [1, 2, 3])
 
     def test_becomes_immutable(self):
-        a = Array([1,2,3])
+        a = Array([1, 2, 3])
         s1 = Signal.range(len(a))
         s2 = Signal.range(len(a))
         v1 = a[s1]
         v2 = a[s2]
-        with self.assertRaisesRegex(ValueError,
-                regex=r"^Array can no longer be mutated after it was indexed with a value at "):
+        with self.assertRaisesRegex(
+                ValueError,
+                regex=
+                r"^Array can no longer be mutated after it was indexed with a value at "
+        ):
             a[1] = 2
-        with self.assertRaisesRegex(ValueError,
-                regex=r"^Array can no longer be mutated after it was indexed with a value at "):
+        with self.assertRaisesRegex(
+                ValueError,
+                regex=
+                r"^Array can no longer be mutated after it was indexed with a value at "
+        ):
             del a[1]
-        with self.assertRaisesRegex(ValueError,
-                regex=r"^Array can no longer be mutated after it was indexed with a value at "):
+        with self.assertRaisesRegex(
+                ValueError,
+                regex=
+                r"^Array can no longer be mutated after it was indexed with a value at "
+        ):
             a.insert(1, 2)
 
     def test_repr(self):
-        a = Array([1,2,3])
+        a = Array([1, 2, 3])
         self.assertEqual(repr(a), "(array mutable [1, 2, 3])")
         s = Signal.range(len(a))
         v = a[s]
@@ -507,7 +536,8 @@ class SignalTestCase(FHDLTestCase):
         self.assertEqual(s11.shape(), (1, False))
         # deprecated
         with warnings.catch_warnings():
-            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
+            warnings.filterwarnings(
+                action="ignore", category=DeprecationWarning)
             d6 = Signal(max=16)
             self.assertEqual(d6.shape(), (4, False))
             d7 = Signal(min=4, max=16)
@@ -520,21 +550,31 @@ class SignalTestCase(FHDLTestCase):
             self.assertEqual(d10.shape(), (0, False))
 
     def test_shape_bad(self):
-        with self.assertRaises(TypeError,
+        with self.assertRaises(
+                TypeError,
                 msg="Width must be a non-negative integer, not '-10'"):
             Signal(-10)
 
     def test_min_max_deprecated(self):
-        with self.assertWarns(DeprecationWarning,
-                msg="instead of `Signal(min=0, max=10)`, use `Signal.range(0, 10)`"):
+        with self.assertWarns(
+                DeprecationWarning,
+                msg=
+                "instead of `Signal(min=0, max=10)`, use `Signal.range(0, 10)`"
+        ):
             Signal(max=10)
         with warnings.catch_warnings():
-            warnings.filterwarnings(action="ignore", category=DeprecationWarning)
-            with self.assertRaises(ValueError,
-                    msg="Lower bound 10 should be less or equal to higher bound 4"):
+            warnings.filterwarnings(
+                action="ignore", category=DeprecationWarning)
+            with self.assertRaises(
+                    ValueError,
+                    msg=
+                    "Lower bound 10 should be less or equal to higher bound 4"
+            ):
                 Signal(min=10, max=4)
-            with self.assertRaises(ValueError,
-                    msg="Only one of bits/signedness or bounds may be specified"):
+            with self.assertRaises(
+                    ValueError,
+                    msg="Only one of bits/signedness or bounds may be specified"
+            ):
                 Signal(2, min=10)
 
     def test_name(self):
@@ -544,8 +584,8 @@ class SignalTestCase(FHDLTestCase):
         self.assertEqual(s2.name, "sig")
 
     def test_name_bad(self):
-        with self.assertRaises(TypeError,
-                msg="Name must be a string, not 'True'"):
+        with self.assertRaises(
+                TypeError, msg="Name must be a string, not 'True'"):
             # A common typo: forgetting to put parens around width and signedness
             Signal(1, True)
 
@@ -555,14 +595,23 @@ class SignalTestCase(FHDLTestCase):
         self.assertEqual(s1.reset_less, True)
 
     def test_reset_narrow(self):
-        with self.assertWarns(SyntaxWarning,
-                msg="Reset value 8 requires 4 bits to represent, but the signal only has 3 bits"):
+        with self.assertWarns(
+                SyntaxWarning,
+                msg=
+                "Reset value 8 requires 4 bits to represent, but the signal only has 3 bits"
+        ):
             Signal(3, reset=8)
-        with self.assertWarns(SyntaxWarning,
-                msg="Reset value 4 requires 4 bits to represent, but the signal only has 3 bits"):
+        with self.assertWarns(
+                SyntaxWarning,
+                msg=
+                "Reset value 4 requires 4 bits to represent, but the signal only has 3 bits"
+        ):
             Signal((3, True), reset=4)
-        with self.assertWarns(SyntaxWarning,
-                msg="Reset value -5 requires 4 bits to represent, but the signal only has 3 bits"):
+        with self.assertWarns(
+                SyntaxWarning,
+                msg=
+                "Reset value -5 requires 4 bits to represent, but the signal only has 3 bits"
+        ):
             Signal((3, True), reset=-5)
 
     def test_attrs(self):
@@ -596,8 +645,9 @@ class SignalTestCase(FHDLTestCase):
 
     def test_decoder(self):
         class Color(Enum):
-            RED  = 1
+            RED = 1
             BLUE = 2
+
         s = Signal(decoder=Color)
         self.assertEqual(s.decoder(1), "RED/1")
         self.assertEqual(s.decoder(3), "3")
@@ -610,8 +660,8 @@ class ClockSignalTestCase(FHDLTestCase):
         s2 = ClockSignal("pix")
         self.assertEqual(s2.domain, "pix")
 
-        with self.assertRaises(TypeError,
-                msg="Clock domain name must be a string, not '1'"):
+        with self.assertRaises(
+                TypeError, msg="Clock domain name must be a string, not '1'"):
             ClockSignal(1)
 
     def test_shape(self):
@@ -622,8 +672,8 @@ class ClockSignalTestCase(FHDLTestCase):
         self.assertEqual(repr(s1), "(clk sync)")
 
     def test_wrong_name_comb(self):
-        with self.assertRaises(ValueError,
-                msg="Domain 'comb' does not have a clock"):
+        with self.assertRaises(
+                ValueError, msg="Domain 'comb' does not have a clock"):
             ClockSignal("comb")
 
 
@@ -634,8 +684,8 @@ class ResetSignalTestCase(FHDLTestCase):
         s2 = ResetSignal("pix")
         self.assertEqual(s2.domain, "pix")
 
-        with self.assertRaises(TypeError,
-                msg="Clock domain name must be a string, not '1'"):
+        with self.assertRaises(
+                TypeError, msg="Clock domain name must be a string, not '1'"):
             ResetSignal(1)
 
     def test_shape(self):
@@ -646,8 +696,8 @@ class ResetSignalTestCase(FHDLTestCase):
         self.assertEqual(repr(s1), "(rst sync)")
 
     def test_wrong_name_comb(self):
-        with self.assertRaises(ValueError,
-                msg="Domain 'comb' does not have a reset"):
+        with self.assertRaises(
+                ValueError, msg="Domain 'comb' does not have a reset"):
             ResetSignal("comb")
 
 
@@ -655,7 +705,7 @@ class MockUserValue(UserValue):
     def __init__(self, lowered):
         super().__init__()
         self.lower_count = 0
-        self.lowered     = lowered
+        self.lowered = lowered
 
     def lower(self):
         self.lower_count += 1
@@ -683,19 +733,19 @@ class SampleTestCase(FHDLTestCase):
         s3 = Sample(ResetSignal(), 1, "sync")
 
     def test_wrong_value_operator(self):
-        with self.assertRaises(TypeError,
-                "Sampled value must be a signal or a constant, not "
+        with self.assertRaises(
+                TypeError, "Sampled value must be a signal or a constant, not "
                 "(+ (sig $signal) (const 1'd1))"):
             Sample(Signal() + 1, 1, "sync")
 
     def test_wrong_clocks_neg(self):
         with self.assertRaises(ValueError,
-                "Cannot sample a value 1 cycles in the future"):
+                               "Cannot sample a value 1 cycles in the future"):
             Sample(Signal(), -1, "sync")
 
     def test_wrong_domain(self):
         with self.assertRaises(TypeError,
-                "Domain name must be a string or None, not 0"):
+                               "Domain name must be a string or None, not 0"):
             Sample(Signal(), 1, 0)
 
 


### PR DESCRIPTION
Allows expressions like `s.matches(37)` and `s.matches("1---000")`

Resolved [issue](https://github.com/m-labs/nmigen/issues/202).

Tested:
* Added test cases
* By inspection using this sample module:

```
from nmigen import *
from nmigen.cli import main
from nmigen.asserts import *


class TestCase(Elaboratable):
    def __init__(self):
        self.input = Signal(8)
        self.output = Signal()

    def elaborate(self, platform):
        m = Module()

        with m.If(self.input.matches(7)):
            m.d.comb += self.output.eq(1)
        with m.Elif(self.input.matches("1---0000")):
            m.d.comb += self.output.eq(1)
        with m.Else():
            m.d.comb += self.output.eq(0)
        return m


if __name__ == "__main__":
    clk = Signal()
    rst = Signal()

    pos = ClockDomain()
    pos.clk = clk
    pos.rst = rst

    testcase = TestCase()

    m = Module()
    m.domains.pos = pos
    m.submodules.testcase = testcase

    main(
        m,
        ports=[clk, rst, testcase.input, testcase.output],
        platform="formal")
```

This properly translates to il:

```
attribute \generator "nMigen"
attribute \nmigen.hierarchy "top.testcase"
module \testcase
  attribute \src "test_case.py:8"
  wire width 8 input 0 \input
  attribute \src "test_case.py:9"
  wire width 1 output 1 \output
  attribute \src "test_case.py:14"
  wire width 1 $1
  attribute \src "test_case.py:14"
  cell $eq $2
    parameter \A_SIGNED 0
    parameter \A_WIDTH 8
    parameter \B_SIGNED 0
    parameter \B_WIDTH 3
    parameter \Y_WIDTH 1
    connect \A \input
    connect \B 3'111
    connect \Y $1
  end
  attribute \src "test_case.py:16"
  wire width 8 $3
  attribute \src "test_case.py:16"
  cell $and $4
    parameter \A_SIGNED 0
    parameter \A_WIDTH 8
    parameter \B_SIGNED 0
    parameter \B_WIDTH 8
    parameter \Y_WIDTH 8
    connect \A \input
    connect \B 8'10001111
    connect \Y $3
  end
  attribute \src "test_case.py:16"
  wire width 1 $5
  attribute \src "test_case.py:16"
  cell $eq $6
    parameter \A_SIGNED 0
    parameter \A_WIDTH 8
    parameter \B_SIGNED 0
    parameter \B_WIDTH 8
    parameter \Y_WIDTH 1
    connect \A $3
    connect \B 8'10000000
    connect \Y $5
  end
  process $group_0
    assign \output 1'0
    attribute \src "test_case.py:14"
    switch { $5 $1 }
      attribute \src "test_case.py:14"
      case 2'-1
        assign \output 1'1
      attribute \src "test_case.py:16"
      case 2'1-
        assign \output 1'1
      attribute \src "test_case.py:18"
      case
        assign \output 1'0
    end
    sync init
  end
end
attribute \generator "nMigen"
attribute \top 1
attribute \nmigen.hierarchy "top"
module \top
  attribute \src "test_case.py:24"
  wire width 1 input 0 \clk
  attribute \src "test_case.py:25"
  wire width 1 input 1 \rst
  attribute \src "test_case.py:8"
  wire width 8 input 2 \input
  attribute \src "test_case.py:9"
  wire width 1 output 3 \output
  cell \testcase \testcase
    connect \input \input
    connect \output \output
  end
end
```

And to Verilog:

```
/* Generated by Yosys 0.9+36 (git sha1 4aa505d1, clang 6.0.0-1ubuntu2 -fPIC -Os) */

(* \nmigen.hierarchy  = "top.testcase" *)
(* generator = "nMigen" *)
module testcase(\output , \input );
  (* src = "test_case.py:14" *)
  wire \$1 ;
  (* src = "test_case.py:16" *)
  wire [7:0] \$3 ;
  (* src = "test_case.py:16" *)
  wire \$5 ;
  (* src = "test_case.py:8" *)
  input [7:0] \input ;
  (* src = "test_case.py:9" *)
  output \output ;
  reg \output ;
  assign \$1  = \input  == (* src = "test_case.py:14" *) 3'h7;
  assign \$3  = \input  & (* src = "test_case.py:16" *) 8'h8f;
  assign \$5  = \$3  == (* src = "test_case.py:16" *) 8'h80;
  always @* begin
    (* src = "test_case.py:14" *)
    casez ({ \$5 , \$1  })
      /* src = "test_case.py:14" */
      2'b?1:
          \output  = 1'h1;
      /* src = "test_case.py:16" */
      2'b1?:
          \output  = 1'h1;
      /* src = "test_case.py:18" */
      default:
          \output  = 1'h0;
    endcase
  end
endmodule

(* \nmigen.hierarchy  = "top" *)
(* top =  1  *)
(* generator = "nMigen" *)
module top(rst, \input , \output , clk);
  (* src = "test_case.py:24" *)
  input clk;
  (* src = "test_case.py:8" *)
  input [7:0] \input ;
  (* src = "test_case.py:9" *)
  output \output ;
  (* src = "test_case.py:25" *)
  input rst;
  testcase testcase (
    .\input (\input ),
    .\output (\output )
  );
endmodule
```

