### PR TITLE
Xilinx specific MultiReg

### DIFF
--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -360,3 +360,11 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                 io_IO=p_port[bit], io_IOB=n_port[bit]
             )
         return m
+
+    def get_multi_reg(self, multireg):
+        m = Module()
+        for i, o in zip((multireg.i, *multireg._regs), multireg._regs):
+            o.attrs["ASYNC_REG"] = "TRUE"
+            m.d[multireg._o_domain] += o.eq(i)
+        m.d.comb += multireg.o.eq(multireg._regs[-1])
+        return m

--- a/nmigen/vendor/xilinx_spartan_3_6.py
+++ b/nmigen/vendor/xilinx_spartan_3_6.py
@@ -411,6 +411,14 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
             )
         return m
 
+    def get_multi_reg(self, multireg):
+        m = Module()
+        for i, o in zip((multireg.i, *multireg._regs), multireg._regs):
+            o.attrs["ASYNC_REG"] = "TRUE"
+            m.d[multireg._o_domain] += o.eq(i)
+        m.d.comb += multireg.o.eq(multireg._regs[-1])
+        return m
+
 
 XilinxSpartan3APlatform = XilinxSpartan3Or6Platform
 XilinxSpartan6Platform = XilinxSpartan3Or6Platform


### PR DESCRIPTION
Vivado was inferring an SRL16 from a MultiReg in some cases. This simply adds an `ASYNC_REG="TRUE"` attribute to the registers.

This code is identical for both 7 series and Spartan which I don't like. I see two possibilities: 

Add something like async_reg_attrs to the platform file and if present apply it to the regs in the MultiReg. It could also be applied to ResetSynchronizer, etc.

A new file, vendor/xilinx_common.py containing code common to all supported Xilinx parts.

I'm happy to do either.