### PR TITLE
vendor.lattice_ecp5: correct a typo in tristate buffer generation

### DIFF
--- a/nmigen/vendor/lattice_ecp5.py
+++ b/nmigen/vendor/lattice_ecp5.py
@@ -397,7 +397,7 @@ class LatticeECP5Platform(TemplatedPlatform):
             if "o" in pin.dir:
                 o = pin_o
             if pin.dir in ("oe", "io"):
-                t = ~pin_oe
+                t = ~pin.oe
         elif pin.xdr == 1:
             # Note that currently nextpnr will not pack an FF (*FS1P3DX) into the PIO.
             if "i" in pin.dir:


### PR DESCRIPTION
Just a quick typo fix. :)