### PR TITLE
class Memory: allow to set default `simulate` value for all generated memory blocks.

### DIFF
--- a/nmigen/hdl/mem.py
+++ b/nmigen/hdl/mem.py
@@ -9,7 +9,10 @@ __all__ = ["Memory", "ReadPort", "WritePort", "DummyPort"]
 
 
 class Memory:
-    def __init__(self, *, width, depth, init=None, name=None, simulate=True):
+    # Configuration options to configure default behaviour for all generated memories
+    # These options should only be set in top level of code and not in modules
+    simulate   = True
+    def __init__(self, *, width, depth, init=None, name=None, simulate=None):
         if not isinstance(width, int) or width < 0:
             raise TypeError("Memory width must be a non-negative integer, not {!r}"
                             .format(width))
@@ -25,6 +28,8 @@ class Memory:
 
         # Array of signals for simulation.
         self._array = Array()
+        if simulate is None:
+            simulate = Memory.simulate
         if simulate:
             for addr in range(self.depth):
                 self._array.append(Signal(self.width, name="{}({})"


### PR DESCRIPTION
I have nmigen code mixed with other RTL language code so am using external simulator. With this option I can now turn off the memory preparation for pysim for all generated blocks.
```python
from nmigen import *

Memory.simulate = False
```
