### PR TITLE
vendor.xilinx_*: Set IOB attribute on cells instead of nets.

### DIFF
--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -175,19 +175,14 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
         def get_dff(clk, d, q):
             # SDR I/O is performed by packing a flip-flop into the pad IOB.
             for bit in range(len(q)):
-                _q = Signal()
-                _q.attrs["IOB"] = "TRUE"
-                # Vivado 2019.1 seems to make this flip-flop ineligible for IOB packing unless
-                # we prevent it from being optimized.
-                _q.attrs["DONT_TOUCH"] = "TRUE"
                 m.submodules += Instance("FDCE",
+                    a_IOB="TRUE",
                     i_C=clk,
                     i_CE=Const(1),
                     i_CLR=Const(0),
                     i_D=d[bit],
-                    o_Q=_q
+                    o_Q=q[bit]
                 )
-                m.d.comb += q[bit].eq(_q)
 
         def get_iddr(clk, d, q1, q2):
             for bit in range(len(q1)):

--- a/nmigen/vendor/xilinx_spartan_3_6.py
+++ b/nmigen/vendor/xilinx_spartan_3_6.py
@@ -212,16 +212,14 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
         def get_dff(clk, d, q):
             # SDR I/O is performed by packing a flip-flop into the pad IOB.
             for bit in range(len(q)):
-                _q = Signal()
-                _q.attrs["IOB"] = "TRUE"
                 m.submodules += Instance("FDCE",
+                    a_IOB="TRUE",
                     i_C=clk,
                     i_CE=Const(1),
                     i_CLR=Const(0),
                     i_D=d[bit],
-                    o_Q=_q,
+                    o_Q=q[bit]
                 )
-                m.d.comb += q[bit].eq(_q)
 
         def get_iddr(clk, d, q0, q1):
             for bit in range(len(q0)):

--- a/nmigen/vendor/xilinx_ultrascale.py
+++ b/nmigen/vendor/xilinx_ultrascale.py
@@ -175,19 +175,14 @@ class XilinxUltraScalePlatform(TemplatedPlatform):
         def get_dff(clk, d, q):
             # SDR I/O is performed by packing a flip-flop into the pad IOB.
             for bit in range(len(q)):
-                _q = Signal()
-                _q.attrs["IOB"] = "TRUE"
-                # Vivado 2019.1 seems to make this flip-flop ineligible for IOB packing unless
-                # we prevent it from being optimized.
-                _q.attrs["DONT_TOUCH"] = "TRUE"
                 m.submodules += Instance("FDCE",
+                    a_IOB="TRUE",
                     i_C=clk,
                     i_CE=Const(1),
                     i_CLR=Const(0),
                     i_D=d[bit],
-                    o_Q=_q
+                    o_Q=q[bit]
                 )
-                m.d.comb += q[bit].eq(_q)
 
         def get_iddr(clk, d, q1, q2):
             for bit in range(len(q1)):


### PR DESCRIPTION
Fixes #263.