### PR TITLE
vendor.intel: silence meaningless warnings

### DIFF
--- a/nmigen/vendor/intel.py
+++ b/nmigen/vendor/intel.py
@@ -38,6 +38,16 @@ class IntelPlatform(TemplatedPlatform):
     speed   = abstractproperty()
     suffix  = ""
 
+    quartus_suppressed_warnings = [
+        10270,  # Incomplete Verilog case statement has no default case item
+        10335,  # Unrecognized synthesis attribute
+        10763,  # Verilog case statement has overlapping case item expressions with non-constant or don't care bits
+        10935,  # Verilog casex/casez overlaps with a previous casex/vasez item expression
+        12125,  # Using design file which is not specified as a design file for the current project, but contains definitions used in project
+        18236,  # Number of processors not specified in QSF
+        292013, # Feature is only available with a valid subscription license
+    ]
+
     required_tools = [
         "quartus_map",
         "quartus_fit",
@@ -100,6 +110,11 @@ class IntelPlatform(TemplatedPlatform):
                 create_clock -period {{1000000000/frequency}} [get_nets {{signal|hierarchy("|")}}]
             {% endfor %}
         """,
+        "{{name}}.srf": r"""
+            {% for warning in platform.quartus_suppressed_warnings %}
+            { "" "" "" "*" {  } {  } 0 {{warning}} "" 0 0 "Design Software" 0 -1 0 ""}
+            {% endfor %}
+        """,      
     }
     command_templates = [
         r"""

--- a/nmigen/vendor/intel.py
+++ b/nmigen/vendor/intel.py
@@ -39,6 +39,7 @@ class IntelPlatform(TemplatedPlatform):
     suffix  = ""
 
     quartus_suppressed_warnings = [
+        10264,  # All case item expressions in this case statement are onehot
         10270,  # Incomplete Verilog case statement has no default case item
         10335,  # Unrecognized synthesis attribute
         10763,  # Verilog case statement has overlapping case item expressions with non-constant or don't care bits
@@ -112,7 +113,7 @@ class IntelPlatform(TemplatedPlatform):
         """,
         "{{name}}.srf": r"""
             {% for warning in platform.quartus_suppressed_warnings %}
-            { "" "" "" "*" {  } {  } 0 {{warning}} "" 0 0 "Design Software" 0 -1 0 ""}
+            { "" "" "" "{{name}}.v" {  } {  } 0 {{warning}} "" 0 0 "Design Software" 0 -1 0 ""}
             {% endfor %}
         """,      
     }


### PR DESCRIPTION
Quartus complains a lot while building Yosys-generated Verilog:

- it fails some subjective lints (warnings 10270, 10763, 10935) that don't affect the semantics (modulo Yosys bugs).
- Quartus doesn't recognise certain attributes like `src` (warning 10335) generated by nMigen.
- Quartus will use its internal IP library whenever you instantiate a megafunction, and warn about it not being within the settings file (warning 12125).
- Quartus complains whenever you set `NUM_PARALLEL_PROCESSORS` to something which isn't all cores (warning 18236).
- Quartus Lite will also complain about unimportant features only being available when you buy Quartus (warning 292013).

These can be silenced through the creation of a `.srf` file (which in this case suppresses all message text with a given ID in `quartus_suppressed_warnings`).

Of these, all but 10335 are effectively harmless. Silencing 10335 has the potential to obscure a misspelt user attribute, so I could remove it if you'd prefer.