### PR TITLE
hdl.ast: Fix width for unary minus operator on signed argument.

### DIFF
--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -556,10 +556,7 @@ class Operator(Value):
             if self.operator in ("+", "~"):
                 return Shape(a_width, a_signed)
             if self.operator == "-":
-                if not a_signed:
-                    return Shape(a_width + 1, True)
-                else:
-                    return Shape(a_width, a_signed)
+                return Shape(a_width + 1, True)
             if self.operator in ("b", "r|", "r&", "r^"):
                 return Shape(1, False)
         elif len(op_shapes) == 2:

--- a/nmigen/test/test_hdl_ast.py
+++ b/nmigen/test/test_hdl_ast.py
@@ -252,7 +252,7 @@ class OperatorTestCase(FHDLTestCase):
         self.assertEqual(v1.shape(), signed(5))
         v2 = -Const(0, signed(4))
         self.assertEqual(repr(v2), "(- (const 4'sd0))")
-        self.assertEqual(v2.shape(), signed(4))
+        self.assertEqual(v2.shape(), signed(5))
 
     def test_add(self):
         v1 = Const(0, unsigned(4)) + Const(0, unsigned(6))


### PR DESCRIPTION
To properly represent a negation of a signed X-bit quantity we may, in
general, need a signed (X+1)-bit signal — for example, negation of
3-bit -4 is 4, which is not representable in signed 3 bits.