### PR TITLE
hdl.ast: replace slice.end by slice.stop in ValueKey

### DIFF
--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -1502,7 +1502,7 @@ class ValueKey:
             self._hash = hash((self.value.operator,
                                tuple(ValueKey(o) for o in self.value.operands)))
         elif isinstance(self.value, Slice):
-            self._hash = hash((ValueKey(self.value.value), self.value.start, self.value.end))
+            self._hash = hash((ValueKey(self.value.value), self.value.start, self.value.stop))
         elif isinstance(self.value, Part):
             self._hash = hash((ValueKey(self.value.value), ValueKey(self.value.offset),
                               self.value.width, self.value.stride))


### PR DESCRIPTION
This patch fixes the following warning which is reported when
RTLIL is generated from a design that uses slices:

    nmigen/nmigen/hdl/ast.py:1505: DeprecationWarning: instead of `slice.end`, use `slice.stop`
        self._hash = hash((ValueKey(self.value.value), self.value.start, self.value.end))

Signed-off-by: Pierre Surply <pierre.surply@lse.epita.fr>