### PR TITLE
Signal: allow to use integral Enum for reset value.

### DIFF
--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -797,7 +797,7 @@ class Signal(Value, DUID):
         name this ``Signal`` is assigned to. Name collisions are automatically resolved by
         prepending names of objects that contain this ``Signal`` and by appending integer
         sequences.
-    reset : int
+    reset : int or integral Enum
         Reset (synchronous) or default (combinatorial) value.
         When this ``Signal`` is assigned to in synchronous context and the corresponding clock
         domain is reset, the ``Signal`` assumes the given value. When this ``Signal`` is unassigned
@@ -833,6 +833,11 @@ class Signal(Value, DUID):
     def __init__(self, shape=None, *, name=None, reset=0, reset_less=False, min=None, max=None,
                  attrs=None, decoder=None, src_loc_at=0):
         super().__init__(src_loc_at=src_loc_at)
+
+        if isinstance(reset, Enum):
+            reset = reset.value
+        if not isinstance(reset, int):
+            raise TypeError("Reset value has to be an int or an integral Enum")
 
         # TODO(nmigen-0.2): move this to nmigen.compat and make it a deprecated extension
         if min is not None or max is not None:

--- a/nmigen/test/test_hdl_ast.py
+++ b/nmigen/test/test_hdl_ast.py
@@ -755,6 +755,14 @@ class SignalTestCase(FHDLTestCase):
         self.assertEqual(s1.reset, 0b111)
         self.assertEqual(s1.reset_less, True)
 
+    def test_reset_enum(self):
+        s1 = Signal(2, reset=UnsignedEnum.BAR)
+        self.assertEqual(s1.reset, 2)
+        with self.assertRaises(TypeError,
+                msg="Reset value has to be an int or an integral Enum"
+        ):
+            Signal(1, reset=StringEnum.FOO)
+
     def test_reset_narrow(self):
         with self.assertWarns(SyntaxWarning,
                 msg="Reset value 8 requires 4 bits to represent, but the signal only has 3 bits"):


### PR DESCRIPTION
Follow-up to #294.
