### PR TITLE
back.verilog: honour write_verilog_opts.

### DIFF
--- a/nmigen/back/verilog.py
+++ b/nmigen/back/verilog.py
@@ -69,9 +69,13 @@ write_verilog -norename {write_verilog_opts}
 
 def convert_fragment(*args, strip_internal_attrs=False, **kwargs):
     rtlil_text, name_map = rtlil.convert_fragment(*args, **kwargs)
-    return _convert_rtlil_text(rtlil_text, strip_internal_attrs=strip_internal_attrs), name_map
+    return _convert_rtlil_text(
+        rtlil_text, strip_internal_attrs=strip_internal_attrs,
+        write_verilog_opts=kwargs.get("write_verilog_opts", ())), name_map
 
 
 def convert(*args, strip_internal_attrs=False, **kwargs):
     rtlil_text = rtlil.convert(*args, **kwargs)
-    return _convert_rtlil_text(rtlil_text, strip_internal_attrs=strip_internal_attrs)
+    return _convert_rtlil_text(
+        rtlil_text, strip_internal_attrs=strip_internal_attrs,
+        write_verilog_opts=kwargs.get("write_verilog_opts", ()))

--- a/nmigen/build/plat.py
+++ b/nmigen/build/plat.py
@@ -282,11 +282,11 @@ class TemplatedPlatform(Platform):
         def emit_rtlil():
             return rtlil_text
 
-        def emit_verilog(opts=()):
+        def emit_verilog(opts=kwargs.get("write_verilog_opts", ())):
             return verilog._convert_rtlil_text(rtlil_text,
                 strip_internal_attrs=True, write_verilog_opts=opts)
 
-        def emit_debug_verilog(opts=()):
+        def emit_debug_verilog(opts=kwargs.get("write_verilog_opts", ())):
             return verilog._convert_rtlil_text(rtlil_text,
                 strip_internal_attrs=False, write_verilog_opts=opts)
 


### PR DESCRIPTION
`write_verilog_opts` is not properly forwarded, this should fix that.