### PR TITLE
build.run: fix indentation.

### DIFF
--- a/nmigen/build/run.py
+++ b/nmigen/build/run.py
@@ -97,7 +97,7 @@ class BuildPlan:
                 else:
                     subprocess.check_call(["sh", "{}.sh".format(self.script)])
 
-                return LocalBuildProducts(os.getcwd())
+            return LocalBuildProducts(os.getcwd())
 
         finally:
             os.chdir(cwd)


### PR DESCRIPTION
Got `None` from  `Platform.execute_local(self, root="build", *, run_script=False)`. This commit fixes that. 