### PR TITLE
Fix `_yosys_version()`

### DIFF
--- a/nmigen/back/verilog.py
+++ b/nmigen/back/verilog.py
@@ -16,7 +16,7 @@ class YosysError(Exception):
 def _yosys_version():
     yosys_path = require_tool("yosys")
     version = subprocess.check_output([yosys_path, "-V"], encoding="utf-8")
-    m = re.match(r"^Yosys ([\d.]+)(?:\+(\d+))?", version)
+    m = re.search(r"^Yosys ([\d.]+)(?:\+(\d+))?", version, flags=re.M)
     tag, offset = m[1], m[2] or 0
     return tuple(map(int, tag.split("."))), offset
 


### PR DESCRIPTION
`re.match` only matches at the beginning of the string, not each line. This change changes it to do a `re.search` with the multiline flag. I think this is primarily of use when the user has compiled yosys with verific extensions.

Example of `yosys -V` output that failed with the prior code:

```
~/s/nmigen · yosys -V
-- (c) Copyright 1999 - 2020 Verific Design Automation Inc. All rights reserved
-- Compilation time was Fri Feb 28 11:19:43 2020

-- This program will expire on Sun Jun  7 12:19:43 2020

Yosys 0.9+2406 (git sha1 cf716e1f, gcc 8.3.0-6 -Os)
```

Verilog generation is still borked, for some reason, I'm still seeing the Verific license info at the top of the Verilog generated through nmigen. Not sure why.

```
-- (c) Copyright 1999 - 2020 Verific Design Automation Inc. All rights reserved
-- Compilation time was Fri Feb 28 11:19:43 2020

-- This program will expire on Sun Jun  7 12:19:43 2020

/* Generated by Yosys 0.9+2406 (git sha1 cf716e1f, gcc 8.3.0-6 -Os) */

(* generator = "nMigen" *)
(* top =  1  *)
(* \nmigen.hierarchy  = "top" *)
module top(clk, rst, o);
```