### PR TITLE
Fixes FileNotFoundError that happens when running formal proofs

### DIFF
--- a/nmigen/test/utils.py
+++ b/nmigen/test/utils.py
@@ -56,7 +56,7 @@ class FHDLTestCase(unittest.TestCase):
     def assertFormal(self, spec, mode="bmc", depth=1):
         caller, *_ = traceback.extract_stack(limit=2)
         spec_root, _ = os.path.splitext(caller.filename)
-        spec_dir = os.path.dirname(spec_root)
+        spec_dir = os.path.dirname(os.path.realpath(spec_root))
         spec_name = "{}_{}".format(
             os.path.basename(spec_root).replace("test_", "spec_"),
             caller.name.replace("test_", "")


### PR DESCRIPTION
Changed assertFormal() in nmigen/test/utils.py to use os.path.realpath(). Running proofs fails otherwise, because nmigen can't find the files