### PR TITLE
Add option to specify spec_name

### DIFF
--- a/nmigen/test/utils.py
+++ b/nmigen/test/utils.py
@@ -53,14 +53,15 @@ class FHDLTestCase(unittest.TestCase):
         if msg is not None:
             self.assertEqual(str(warns[0].message), msg)
 
-    def assertFormal(self, spec, mode="bmc", depth=1, engine="smtbmc"):
+    def assertFormal(self, spec, mode="bmc", depth=1, engine="smtbmc", spec_name=None):
         caller, *_ = traceback.extract_stack(limit=2)
         spec_root, _ = os.path.splitext(caller.filename)
         spec_dir = os.path.dirname(spec_root)
-        spec_name = "{}_{}".format(
-            os.path.basename(spec_root).replace("test_", "spec_"),
-            caller.name.replace("test_", "")
-        )
+        if spec_name is None:
+            spec_name = "{}_{}".format(
+                os.path.basename(spec_root).replace("test_", "spec_"),
+                caller.name.replace("test_", "")
+            )
 
         # The sby -f switch seems not fully functional when sby is reading from stdin.
         if os.path.exists(os.path.join(spec_dir, spec_name)):


### PR DESCRIPTION
When attempting to parallelize verification tasks from within the same file, the `sby` verification tasks may encounter an error due to an attempt to access the same directory simultaneously, arising from a name collision in the generated `spec_name`. Adding the option to specify `spec_name` within `assertFormal` allows the caller to manually resolve such issues, while maintaining full backwards compatibility with existing scripts.