### PR TITLE
Update UART Example so that acknowledging RX data sets RX ready low.

### DIFF
--- a/examples/basic/uart.py
+++ b/examples/basic/uart.py
@@ -71,6 +71,8 @@ class UART(Elaboratable):
                     ]
                 with m.Else():
                     m.d.sync += self.rx_ovf.eq(1)
+            with m.If(self.rx_ack):
+                m.d.sync += self.rx_rdy.eq(0)
         with m.Else():
             with m.If(rx_phase != 0):
                 m.d.sync += rx_phase.eq(rx_phase - 1)
@@ -135,6 +137,10 @@ if __name__ == "__main__":
 
             yield uart.rx_ack.eq(1)
             yield
+            yield uart.rx_ack.eq(0)
+            yield
+            assert not (yield uart.rx_rdy)
+            
         sim.add_sync_process(transmit_proc)
 
         with sim.write_vcd("uart.vcd", "uart.gtkw"):


### PR DESCRIPTION
The UART example code currently sets `rx_rdy` high when data has been received. I had assumed that setting `rx_ack` to high would clear this until data is ready again, but in the existing implementation `rx_rdy` only goes low when new data arrives. This small diff changes `rx_ack` to clear `rx_rdy` so that a user can acknowledge data after the first byte and then wait on `rx_rdy` for the next one. It also updates the simulation to verify that the right thing happens.

I suppose this could've been design with the intent that the user strobes out a signal when `rx_rdy` goes from low to high, but I'm not sure what the use of `rx_ack` is if this was the intended design. Sorry if I'm being oblivious, but if I am, feel free to close out this diff.